### PR TITLE
Implement a popup authenticator

### DIFF
--- a/packages/ember-simple-auth/addon/authenticators/popup-base.js
+++ b/packages/ember-simple-auth/addon/authenticators/popup-base.js
@@ -1,0 +1,188 @@
+import RSVP from 'rsvp';
+import BaseAuthenticator from './base';
+import { guidFor } from '@ember/object/internals';
+import assign from '../utils/assign';
+
+export function applyDefaultOptions(optionsToMerge, center = true) {
+  let options = assign(
+    {
+      toolbar: false,
+      location: false,
+      directories: false,
+      status: false,
+      menubar: false,
+      scrollbars: false,
+      resizable: false,
+      copyhistory: false,
+      width: 500,
+      height: 500,
+    },
+    optionsToMerge
+  );
+
+  if (center) {
+    options.top =
+      window.top.outerHeight / 2 + window.top.screenY - options.height / 2;
+    options.left =
+      window.top.outerWidth / 2 + window.top.screenX - options.width / 2;
+  }
+
+  return options;
+}
+
+export function stringyfyWindowOptions(options) {
+  return Object.keys(options)
+    .map(
+      (option) =>
+        `${option}=${
+          typeof options[option] === 'boolean'
+            ? Number(options[option])
+            : options[option]
+        }`
+    )
+    .join(',');
+}
+
+/**
+ * Open a popup window and wait until it resolves with an url.
+ * Expects the popup to redirect to a known HTML page within the project which triggers a message event.
+ * Rejects the promise if the popup is closed before that happens.
+ *
+ * @param {string} url
+ * @param {*} additional options passed to window.open
+ * @returns {Promise<string>}
+ */
+export function openPopup(href, options = {}, center = true) {
+  let popupWindow;
+  let detach;
+  let id = guidFor(new Date());
+
+  return new RSVP.Promise((resolve, reject) => {
+    let onMessage = (event) => {
+      // Skip messages from other child windows and with different signatures
+      if (event.source !== popupWindow || event.data !== id) {
+        return;
+      }
+
+      detach();
+      resolve(event.source.location.href);
+    };
+
+    let onBeforeUnload = () => {
+      if (!popupWindow || popupWindow.closed) {
+        return;
+      }
+
+      popupWindow.close();
+    };
+
+    detach = () => {
+      window.removeEventListener('message', onMessage);
+      window.removeEventListener('unload', onBeforeUnload);
+    };
+
+    window.addEventListener('message', onMessage);
+    window.addEventListener('beforeunload', onBeforeUnload);
+
+    popupWindow = window.open(
+      href,
+      id,
+      stringyfyWindowOptions(applyDefaultOptions(options, center))
+    );
+
+    // If the popup is closed before it redicted, reject
+    let interval = setInterval(() => {
+      if (popupWindow.closed) {
+        clearInterval(interval);
+        detach();
+        reject();
+      }
+    }, 500);
+  });
+}
+
+/**
+ * @returns {string} an acceptably random string with 10 characters
+ */
+export function pseudoRandomString() {
+  return Math.random()
+    .toString(36)
+    .replace(/[^a-z0-9]+/g, '')
+    .substring(0, 10);
+}
+
+export default BaseAuthenticator.extend({
+  redirectUrl: `${window.location.origin}/.well-known/ember-simple-auth-redirect.html`,
+  authorizationUrl: '',
+
+  redirectUrlKey: 'redirect_uri',
+  stateKey: 'state',
+  codeKey: 'code',
+
+  restore(data) {
+    return RSVP.resolve(data);
+  },
+
+  authenticate(options) {
+    let state = pseudoRandomString();
+
+    return openPopup(this.buildAuthorizationUrl({ options, state }))
+      .then((href) => this.parseResponse(state, href))
+      .catch(() => RSVP.reject('popup was closed without authentication'))
+      .then((data) => this.exchangeCodeForToken(data));
+  },
+
+  invalidate() {
+    return RSVP.resolve();
+  },
+
+  /**
+   *
+   * @param {any} options
+   *
+   * @returns {String}
+   */
+  buildAuthorizationUrl({ state }) {
+    const url = new URL(this.authorizationUrl);
+
+    url.searchParams.set(this.redirectUrlKey, this.redirectUrl);
+    url.searchParams.set(this.stateKey, state);
+
+    return url.toString();
+  },
+
+  /**
+   * Parses the response from the popup window.
+   * Override this method to handle the response in a different way.
+   *
+   * @param {string} href
+   *
+   * @returns {Promise<any>}
+   */
+  parseResponse({ href, state: _state }) {
+    let url = new URL(href);
+    let code = url.searchParams.get(this.codeKey);
+    let state = url.searchParams.get(this.stateKey);
+
+    if (!code) {
+      throw new Error(`no ${this.codeKey} in response`);
+    }
+
+    if (!state) {
+      throw new Error('no state in response');
+    }
+
+    if (state !== _state) {
+      throw new Error(`${this.stateKey} does not match`);
+    }
+
+    return { code };
+  },
+
+  /**
+   *
+   */
+  exchangeCodeForToken(/* data */) {
+    throw new Error('exchangeCodeForToken not implemented');
+  },
+});

--- a/packages/ember-simple-auth/addon/public/.well-known/ember-simple-auth-redirect.html
+++ b/packages/ember-simple-auth/addon/public/.well-known/ember-simple-auth-redirect.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><meta charset="UTF-8"><title></title><script>opener.postMessage(''+name);close();</script>

--- a/packages/ember-simple-auth/tests/unit/authenticators/popup-base-test.js
+++ b/packages/ember-simple-auth/tests/unit/authenticators/popup-base-test.js
@@ -1,0 +1,46 @@
+import PopupBaseAuthenticator from 'ember-simple-auth/authenticators/popup-base';
+import { module, test } from 'qunit';
+
+module('PopupBaseAuthenticator', function(hooks) {
+  let authenticator;
+
+  hooks.beforeEach(function() {
+    authenticator = PopupBaseAuthenticator.create();
+  });
+
+  module('#restore', function() {
+    test('returns a rejecting promise', async function(assert) {
+      assert.expect(1);
+      try {
+        await authenticator.restore();
+        assert.ok(false);
+      } catch (_error) {
+        assert.ok(true);
+      }
+    });
+  });
+
+  module('#authenticate', function() {
+    test('returns a rejecting promise', async function(assert) {
+      assert.expect(1);
+      try {
+        await authenticator.authenticate();
+        assert.ok(false);
+      } catch (_error) {
+        assert.ok(true);
+      }
+    });
+  });
+
+  module('#invalidate', function() {
+    test('returns a resolving promise', async function(assert) {
+      assert.expect(1);
+      try {
+        await authenticator.invalidate();
+        assert.ok(true);
+      } catch (_error) {
+        assert.ok(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
This aims to be the foundation for replacing the deprecated and abandoned torii ember addon and the authenticator we deprecated that relied on it.

Scope of this PR / authenticator:

- Provide a base implementation
- Open a third party (oAuth1/2) login page in a managed popup
- Handle the authentication redirect and closing of the popup
- Make it easy to extend the authenticator to your needs (e.g. by adopting certain torii providers)

**Not part of the scope** of this PR / authenticator:

- Include and replicate all providers included by torii

#### Todo

- [x] Figure out if this is a sensible way forward
- [ ] Write tests
- [ ] Provide documentation
- [ ] Provide migration guide going from torii to this