### PR TITLE
Add embroider tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     'plugin:ember/recommended',
   ],
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2022,
     sourceType: 'module'
   },
   rules: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
           - workspace: test-app
             test-suite: "test:one ember-canary"
             allow-failure: true
+          - workspace: ember-simple-auth
+            test-suite: "test:one embroider-safe"
+          - workspace: ember-simple-auth
+            test-suite: "test:one embroider-optimized"
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3

--- a/packages/ember-simple-auth/addon/-internals/routing.js
+++ b/packages/ember-simple-auth/addon/-internals/routing.js
@@ -55,7 +55,7 @@ export function handleSessionInvalidated(owner, routeAfterInvalidation) {
     routerService.transitionTo(routeAfterInvalidation);
   } else {
     if (!Ember.testing) {
-      location().replace(routeAfterInvalidation);
+      location.replace(routeAfterInvalidation);
     }
   }
 }

--- a/packages/ember-simple-auth/addon/utils/location.js
+++ b/packages/ember-simple-auth/addon/utils/location.js
@@ -1,1 +1,11 @@
-export default () => window.location;
+class LocationUtil {
+  location = window.location;
+  
+  replace(...args) {
+    this.location.replace(...args);
+  }
+}
+
+const location = new LocationUtil();
+
+export default location;

--- a/packages/ember-simple-auth/config/ember-try.js
+++ b/packages/ember-simple-auth/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = function() {
   return Promise.all([
@@ -219,7 +220,22 @@ module.exports = function() {
           npm: {
             devDependencies: {}
           }
-        }
+        },
+        embroiderSafe({
+          npm: {
+            devDependencies: {
+              torii: null,
+              'ember-data': '~4.4.0',
+            }
+          }
+        }),
+        embroiderOptimized({
+          npm: {
+            devDependencies: {
+              'ember-data': '~4.4.0',
+            }
+          }
+        })
       ]
     };
   });

--- a/packages/ember-simple-auth/ember-cli-build.js
+++ b/packages/ember-simple-auth/ember-cli-build.js
@@ -1,8 +1,8 @@
 'use strict';
 
 /* eslint-disable no-var, object-shorthand */
-
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const { maybeEmbroider } = require('@embroider/test-setup');
 
 var sourceTrees = [];
 
@@ -21,5 +21,5 @@ module.exports = function(defaults) {
     }
   });
 
-  return app.toTree(sourceTrees);
+  return maybeEmbroider(app);
 };

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "~2.7.0",
+    "@embroider/test-setup": "^1.8.3",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
     "babel-eslint": "^10.1.0",

--- a/packages/ember-simple-auth/tests/unit/services/session-test.js
+++ b/packages/ember-simple-auth/tests/unit/services/session-test.js
@@ -6,7 +6,7 @@ import { next } from '@ember/runloop';
 import EmberObject, { set } from '@ember/object';
 import { registerDeprecationHandler } from '@ember/debug';
 import sinonjs from 'sinon';
-import * as LocationUtil from 'ember-simple-auth/utils/location';
+import LocationUtil from 'ember-simple-auth/utils/location';
 import Configuration from 'ember-simple-auth/configuration';
 import RSVP from 'rsvp';
 
@@ -529,8 +529,7 @@ module('SessionService', function(hooks) {
         this.owner.register('service:fastboot', Service.extend({
           isFastBoot: false
         }));
-        sinon.stub(LocationUtil, 'default').returns({ replace() {} });
-        sinon.spy(LocationUtil.default(), 'replace');
+        sinon.stub(LocationUtil, 'replace').returns(function() {});
         // eslint-disable-next-line ember/no-ember-testing-in-module-scope
         Ember.testing = false;
       });
@@ -543,7 +542,7 @@ module('SessionService', function(hooks) {
       test('replaces the location with the route', function(assert) {
         sessionService.handleInvalidation('index');
 
-        assert.ok(LocationUtil.default().replace.calledWith('index'));
+        assert.ok(LocationUtil.replace.calledWith('index'));
       });
     });
   });

--- a/packages/ember-simple-auth/tests/unit/utils/location-test.js
+++ b/packages/ember-simple-auth/tests/unit/utils/location-test.js
@@ -1,13 +1,6 @@
 import { module, test } from 'qunit';
-import * as LocationUtil from 'ember-simple-auth/utils/location';
+import LocationUtil from 'ember-simple-auth/utils/location';
 import sinonjs from 'sinon';
-
-// eslint-disable-next-line
-const foo = {
-  get hash() {
-    return LocationUtil.default().hash;
-  }
-};
 
 module('Unit | Utility | location', function(hooks) {
   let sinon;
@@ -18,7 +11,7 @@ module('Unit | Utility | location', function(hooks) {
     sinon.restore();
   });
   test('works', function(assert) {
-    assert.ok(LocationUtil.default());
-    assert.equal(typeof LocationUtil.default().hash, 'string');
+    assert.ok(LocationUtil);
+    assert.equal(typeof LocationUtil.replace, 'function');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,6 +1307,14 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
+"@embroider/test-setup@^1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-1.8.3.tgz#445b9fe5a363ce50367ac2114750597f98d7806d"
+  integrity sha512-BCCbBG7UWkCw+cQ401Ip6LnqTRaQDeKImxR+e7Q4oP6H4EBj7p4iGR1z6fhMy4NNyXKPB6jk3bGa9bTiiNoEAw==
+  dependencies:
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"


### PR DESCRIPTION
Webpack imports don't allow to override `default()` on a module.
Location util needed to be refactored so it proxies to `window.replace` and allow us to listen to the proxy method instead.

- changes how util/location works
- adds embroider tests