### PR TITLE
chore: disallow failure for ember-simple-auth embroider tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,10 @@ jobs:
             allow-failure: true
           - workspace: ember-simple-auth
             test-suite: "test:one embroider-safe"
+            allow-failure: false
           - workspace: ember-simple-auth
             test-suite: "test:one embroider-optimized"
+            allow-failure: false
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3


### PR DESCRIPTION
- the CI definition doesn't expect allow-failure to be blank, so it explicitly sets it to `false` now.