### PR TITLE
Remove unused base64 dependency

### DIFF
--- a/packages/ember-simple-auth/index.js
+++ b/packages/ember-simple-auth/index.js
@@ -1,42 +1,8 @@
 'use strict';
 
 /* eslint-env node */
-/* eslint-disable no-var, object-shorthand, prefer-template */
-
-var path = require('path');
-var Funnel = require('broccoli-funnel');
 
 module.exports = {
-  name: 'ember-simple-auth',
-
-  included() {
-    this._super.included.apply(this, arguments);
-    this._ensureThisImport();
-
-    this.import('vendor/base64.js');
-  },
-
-  treeForVendor() {
-    return new Funnel(path.dirname(require.resolve('base-64')), {
-      files: ['base64.js']
-    });
-  },
-
-  _ensureThisImport: function() {
-    if (!this.import) {
-      this._findHost = function findHostShim() {
-        var current = this;
-        var app;
-        do {
-          app = current.app || app;
-        } while (current.parent.parent && (current = current.parent));
-        return app;
-      };
-      this.import = function importShim(asset, options) {
-        var app = this._findHost();
-        app.import(asset, options);
-      };
-    }
-  }
+  name: 'ember-simple-auth'
 };
 

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -25,8 +25,6 @@
     "test:node": "mocha node-tests --recursive"
   },
   "dependencies": {
-    "base-64": "^1.0.0",
-    "broccoli-funnel": "^3.0.0",
     "ember-cli-babel": "^7.20.5",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cookies": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,11 +3283,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-64@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
-  integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
-
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -3710,7 +3705,7 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.0, broccoli-funnel@^3.0.3, broccoli-funnel@^3.0.8:
+broccoli-funnel@^3.0.3, broccoli-funnel@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz#f5b62e2763c3918026a15a3c833edc889971279b"
   integrity sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==


### PR DESCRIPTION
- removes base64 dependency, it appears to be unused 
https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v3.md#dont-rely-on-client-id-being-sent-as-a-header

Once https://github.com/mainmatter/ember-simple-auth/pull/2491 is merged, this could get updated to get additional cleanup in.