### PR TITLE
chore: pin ember-qunit

### DIFF
--- a/packages/classic-test-app/package.json
+++ b/packages/classic-test-app/package.json
@@ -44,7 +44,7 @@
     "ember-fetch": "^8.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-qunit": "^6.0.0",
+    "ember-qunit": "6.0.0",
     "ember-resolver": "^8.0.0",
     "ember-simple-auth": "4.2.2",
     "ember-source": "~4.4.0",

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -55,7 +55,7 @@
     "ember-fetch": "^8.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-qunit": "^6.0.0",
+    "ember-qunit": "6.0.0",
     "ember-resolver": "^8.0.0",
     "ember-source": "~4.4.0",
     "ember-source-channel-url": "^3.0.0",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -45,7 +45,7 @@
     "ember-fetch": "^8.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-qunit": "^6.0.0",
+    "ember-qunit": "6.0.0",
     "ember-resolver": "^8.0.0",
     "ember-simple-auth": "4.2.2",
     "ember-source": "~4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6034,7 +6034,7 @@ ember-maybe-import-regenerator@^1.0.0:
     ember-cli-babel "^7.26.6"
     regenerator-runtime "^0.13.2"
 
-ember-qunit@^6.0.0:
+ember-qunit@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-6.0.0.tgz#cea4766c297a25d58a3e886ccd4eb726167ea47c"
   integrity sha512-idNWh9Ap2HN9e3Xozh5Jrciu5tDhn0okM/bgwDjdks3dwuMhEox45iiRTx469FWQ9+ixjZ40AsXsRTDkfCmvmw==


### PR DESCRIPTION
Pins ember-qunit to 6.0.0.
ember-qunit 6.1.0 added a peerDependency on `ember-source` which is now failing dependency-checker during build time.
https://github.com/mainmatter/ember-simple-auth/actions/runs/3862857848/jobs/6584686436