### PR TITLE
chore: remove ember-canary from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,15 +85,6 @@ jobs:
             test-suite: "test:one ember-release"
             allow-failure: true
           - workspace: ember-simple-auth
-            test-suite: "test:one ember-canary"
-            allow-failure: true
-          - workspace: classic-test-app
-            test-suite: "test:one ember-canary"
-            allow-failure: true
-          - workspace: test-app
-            test-suite: "test:one ember-canary"
-            allow-failure: true
-          - workspace: ember-simple-auth
             test-suite: "test:one embroider-safe"
             allow-failure: false
           - workspace: ember-simple-auth


### PR DESCRIPTION
- removes ember-canary from CI test-suite
Reason being that ember-canary has been failing to run for a very long period of time with error, resulting in CI hanging job until it timeouts

```
(node:1938) UnhandledPromiseRejectionWarning: Error: Unable to require module 'crypto' because it was not in the whitelist.
    at Object.require (/home/runner/work/ember-simple-auth/ember-simple-auth/node_modules/fastboot/src/fastboot-schema.js:191:15)
    at Module.callback (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/addon-tree-output/@ember-data/store/index-12e1fcb9.js:159:1)
    at Module.exports (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:106:1)
    at Module._reify (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:143:1)
    at Module.reify (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:130:1)
    at Module.exports (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:104:1)
    at Module._reify (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:143:1)
    at Module.reify (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:130:1)
    at Module.exports (/tmp/tests-dist-2023010-1[93](https://github.com/mainmatter/ember-simple-auth/actions/runs/3881561302/jobs/6620704939#step:7:94)8-1vfafhn.t3dd/assets/vendor/loader/loader.js:104:1)
    at Module._reify (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:143:1)
    at Module.reify (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:130:1)
    at Module.exports (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:104:1)
    at requireModule (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:27:1)
    at r (/tmp/tests-dist-2023010-1938-1vfafhn.t3dd/assets/vendor/loader/loader.js:176:1)
```
https://github.com/mainmatter/ember-simple-auth/actions/runs/3881561302/jobs/6620704939