### PR TITLE
refactor(cleanup): remove ember-data from ESA addon

### DIFF
--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -49,7 +49,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "4.0.2",
     "ember-cli-yuidoc": "^0.9.1",
-    "ember-data": "~3.18.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,32 +1012,12 @@
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/adapter@3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.18.0.tgz#0e25af9357d632bccb90df3109c679e922a64a25"
-  integrity sha512-fNFbnHF+QM9QAwd+AF131QRUM9P2W5mE5hycVyaHVfBPdNSDCJI85Ca+nwFF1GfwzImlUojUAyW5z+MzJCXhEw==
-  dependencies:
-    "@ember-data/private-build-infra" "3.18.0"
-    "@ember-data/store" "3.18.0"
-    "@ember/edition-utils" "^1.2.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-
 "@ember-data/canary-features@3.17.1":
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.17.1.tgz#98b8e9b60ab4f4c963d49f87a062b07af6bcf457"
   integrity sha512-lURx2257kAtluASlpQyH3AgAi5S6t/q3OeYh7fmISLTeUrDrAF2MyYcW3YfQOod3Us8U4Q4daCxdvEQ8grQULQ==
   dependencies:
     ember-cli-babel "^7.13.2"
-    ember-cli-typescript "^3.1.3"
-
-"@ember-data/canary-features@3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.18.0.tgz#cc94867a8d6309d7dff48143c79497c43fd301d2"
-  integrity sha512-NRddFSlqdN5D86MKBgJ4MQzAzKHGQasDOWCEoGJHMF/Muh3I1NqAVAtI/I68wPr/k1j5hP1wMT6/tBsBMJXb/Q==
-  dependencies:
-    ember-cli-babel "^7.18.0"
     ember-cli-typescript "^3.1.3"
 
 "@ember-data/debug@3.17.1":
@@ -1051,17 +1031,6 @@
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/debug@3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.18.0.tgz#3ce284ce89e83b05ceae81a5be03248a341591fb"
-  integrity sha512-9g/ghkq8SLmbOG0UUTyeX0ZAmQ3j3us2Ajkg8u3pVDKEpNdbQLhU5Npd9rf5gJe1TKmLcH7AcDpu85ZPLbb69w==
-  dependencies:
-    "@ember-data/private-build-infra" "3.18.0"
-    "@ember/edition-utils" "^1.2.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-
 "@ember-data/model@3.17.1":
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.17.1.tgz#2891ec0947f7111d93f24988922468e9d88c9b8a"
@@ -1072,22 +1041,6 @@
     "@ember-data/store" "3.17.1"
     "@ember/edition-utils" "^1.2.0"
     ember-cli-babel "^7.13.2"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-    ember-compatibility-helpers "^1.2.0"
-    inflection "1.12.0"
-
-"@ember-data/model@3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.18.0.tgz#f2aebb34005dd2926cf11810d3b3cf7f2cc6c5ff"
-  integrity sha512-faFCpBl6VBzPl6tcJKi7FVEnC9xcx3qnle70tJWTAC++MK+GHlpQofNPWVu6cCebfDojHrLszfxjrDzmjvizqQ==
-  dependencies:
-    "@ember-data/canary-features" "3.18.0"
-    "@ember-data/private-build-infra" "3.18.0"
-    "@ember-data/store" "3.18.0"
-    "@ember/edition-utils" "^1.2.0"
-    ember-cli-babel "^7.18.0"
     ember-cli-string-utils "^1.1.0"
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
@@ -1126,38 +1079,6 @@
     semver "^7.1.1"
     silent-error "^1.1.1"
 
-"@ember-data/private-build-infra@3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.18.0.tgz#4420c375fa2462946ad6f9c62f73b79bba4d0e87"
-  integrity sha512-iQ4TzYdDCm0awv7S0Xg0AfQCDfwkl5pTCk7G8DfzbA3IIGJ0sFR19cq1IZkNKxqTUzU5ecb+394YybHjz81hMQ==
-  dependencies:
-    "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@ember-data/canary-features" "3.18.0"
-    "@ember/edition-utils" "^1.2.0"
-    babel-plugin-debug-macros "^0.3.3"
-    babel-plugin-filter-imports "^4.0.0"
-    babel6-plugin-strip-class-callcheck "^6.0.0"
-    broccoli-debug "^0.6.5"
-    broccoli-file-creator "^2.1.1"
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^4.1.0"
-    broccoli-rollup "^4.1.1"
-    calculate-cache-key-for-tree "^2.0.0"
-    chalk "^3.0.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-path-utils "^1.0.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^3.1.3"
-    ember-cli-version-checker "^4.1.0"
-    esm "^3.2.25"
-    git-repo-info "^2.1.1"
-    glob "^7.1.6"
-    npm-git-info "^1.0.3"
-    rimraf "^3.0.2"
-    rsvp "^4.8.5"
-    semver "^7.1.3"
-    silent-error "^1.1.1"
-
 "@ember-data/record-data@3.17.1":
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.17.1.tgz#1b5642dbe6ed0a4af7f3eeb05fe4945efecc4085"
@@ -1169,20 +1090,6 @@
     "@ember/edition-utils" "^1.2.0"
     "@ember/ordered-set" "^2.0.3"
     ember-cli-babel "^7.13.2"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-
-"@ember-data/record-data@3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.18.0.tgz#c98e55e74950c3383080a5deb5b32a7210c2919e"
-  integrity sha512-WRrqBjFbD5tHeKnda+lvN9+3cPV/tJE0dkZIebheCvnkqueeGgp0+CW8ASp2iFySqRsBjlSxt1g46YrRdKVJtA==
-  dependencies:
-    "@ember-data/canary-features" "3.18.0"
-    "@ember-data/private-build-infra" "3.18.0"
-    "@ember-data/store" "3.18.0"
-    "@ember/edition-utils" "^1.2.0"
-    "@ember/ordered-set" "^2.0.3"
-    ember-cli-babel "^7.18.0"
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
 
@@ -1202,17 +1109,6 @@
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/serializer@3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.18.0.tgz#d61fa2a11f6875f73bfdb492d316f052aa12b6ad"
-  integrity sha512-YBDHtGBxsHTIkk3c5ok3TrM3JCD2iW1n427Qe0v3/QMQCxX3eKT4rS8p0PP/orT5sUZ05zNOw6HlKfdEUKqAhA==
-  dependencies:
-    "@ember-data/private-build-infra" "3.18.0"
-    "@ember-data/store" "3.18.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-
 "@ember-data/store@3.17.1":
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.17.1.tgz#5dbe381a68f652d1550267f4729adef069746fd6"
@@ -1221,18 +1117,6 @@
     "@ember-data/canary-features" "3.17.1"
     "@ember-data/private-build-infra" "3.17.1"
     ember-cli-babel "^7.13.2"
-    ember-cli-path-utils "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-    heimdalljs "^0.3.0"
-
-"@ember-data/store@3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.18.0.tgz#04f7734a1f654c4eaf999f94f5a1451e763b7670"
-  integrity sha512-FBfXqRct3khpUsdusdFVFt8qNrWDPpqT/V0wFnwjSje5uX+DSwZ247SrtCYkwf6OziSzOfWR/w286O+0nawAyQ==
-  dependencies:
-    "@ember-data/canary-features" "3.18.0"
-    "@ember-data/private-build-infra" "3.18.0"
-    ember-cli-babel "^7.18.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-typescript "^3.1.3"
     heimdalljs "^0.3.0"
@@ -5908,26 +5792,6 @@ ember-data@~3.17.0:
     "@glimmer/env" "^0.1.7"
     broccoli-merge-trees "^4.1.0"
     ember-cli-babel "^7.13.2"
-    ember-cli-typescript "^3.1.3"
-    ember-inflector "^3.0.1"
-
-ember-data@~3.18.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.18.0.tgz#e7c27e311b62f986e55075dc61ca581e7c74a4d3"
-  integrity sha512-8P5A6Il7X0QQJRJA4OXdX7yOc8A5/befxfbFBNTzi2Ptq+m2zNBfdW98lfPb9M6h3GMjwsZCmVlNVK6ic8dmMA==
-  dependencies:
-    "@ember-data/adapter" "3.18.0"
-    "@ember-data/debug" "3.18.0"
-    "@ember-data/model" "3.18.0"
-    "@ember-data/private-build-infra" "3.18.0"
-    "@ember-data/record-data" "3.18.0"
-    "@ember-data/serializer" "3.18.0"
-    "@ember-data/store" "3.18.0"
-    "@ember/edition-utils" "^1.2.0"
-    "@ember/ordered-set" "^2.0.3"
-    "@glimmer/env" "^0.1.7"
-    broccoli-merge-trees "^4.1.0"
-    ember-cli-babel "^7.18.0"
     ember-cli-typescript "^3.1.3"
     ember-inflector "^3.0.1"
 


### PR DESCRIPTION
- removes ember-data from `ember-simple-auth` addon.
ESA addon doesn't use ember-data internally, just the test-apps.