### PR TITLE
chore: enable ember-default in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           - test:one ember-4.0
           - test:one ember-lts-4.4
           - test:one ember-lts-4.8
+          - test:one ember-default
         allow-failure: [false]
         include:
           - workspace: ember-simple-auth


### PR DESCRIPTION
- enables `ember-default` in CI
This should make sure that the apps and addon work correctly on a fresh clone.