### PR TITLE
chore: prolong Torri authenticator deprecation period until v6

### DIFF
--- a/packages/ember-simple-auth/addon/authenticators/torii.js
+++ b/packages/ember-simple-auth/addon/authenticators/torii.js
@@ -6,7 +6,7 @@ import BaseAuthenticator from './base';
 
 deprecate('Ember Simple Auth: The Torii authenticator is deprecated.', false, {
   id: 'ember-simple-auth.authenticators.torii',
-  until: '5.0.0',
+  until: '6.0.0',
   for: 'ember-simple-auth',
   since: {
     enabled: '4.2.0'


### PR DESCRIPTION
We won't be able to migrate from Torii or recommend a solution until v5.
Torii initially got deprecated due to being unable to run under Ember v4.
For now this has changed and gave us a little bit more leeway: https://github.com/adopted-ember-addons/torii 