### PR TITLE
chore(deps): remove jsdom resolutions

### DIFF
--- a/packages/classic-test-app/package.json
+++ b/packages/classic-test-app/package.json
@@ -72,8 +72,7 @@
   ],
   "resolutions": {
     "@babel/plugin-transform-typescript": "~7.21.0",
-    "cssstyle": "~3.0.0",
-    "jsdom": "^20.0.0"
+    "cssstyle": "~3.0.0"
   },
   "ember": {
     "edition": "octane"

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -88,8 +88,7 @@
   },
   "resolutions": {
     "@babel/plugin-transform-typescript": "~7.21.0",
-    "cssstyle": "~3.0.0",
-    "jsdom": "^20.0.0"
+    "cssstyle": "~3.0.0"
   },
   "peerDependencies": {
     "ember-fetch": "^8.0.1"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -76,8 +76,7 @@
   ],
   "resolutions": {
     "@babel/plugin-transform-typescript": "~7.21.0",
-    "cssstyle": "~3.0.0",
-    "jsdom": "^20.0.0"
+    "cssstyle": "~3.0.0"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
- removes jsdom from resolutions.

Renovate keeps updating it everytime which pretty much means it's useless.
Fastboot seems to be the dependency that uses it.