### PR TITLE
chore(deps): remove typescript-transform resolution

### DIFF
--- a/packages/classic-test-app/package.json
+++ b/packages/classic-test-app/package.json
@@ -70,9 +70,6 @@
   "fastbootDependencies": [
     "node-fetch"
   ],
-  "resolutions": {
-    "@babel/plugin-transform-typescript": "~7.21.0"
-  },
   "ember": {
     "edition": "octane"
   }

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -86,9 +86,6 @@
       "ember": ">=3.12"
     }
   },
-  "resolutions": {
-    "@babel/plugin-transform-typescript": "~7.21.0"
-  },
   "peerDependencies": {
     "ember-fetch": "^8.0.1"
   },

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -74,9 +74,6 @@
     "node-fetch",
     "crypto"
   ],
-  "resolutions": {
-    "@babel/plugin-transform-typescript": "~7.21.0"
-  },
   "ember": {
     "edition": "octane"
   }


### PR DESCRIPTION
- Removes @babel/plugin-transform-typescript resolution
Similarly to #2528 it's being constantly updated and I'm not sure why we'd need it.