### PR TITLE
Re-polyfill Assign

### DIFF
--- a/packages/ember-simple-auth/addon/utils/assign.js
+++ b/packages/ember-simple-auth/addon/utils/assign.js
@@ -1,3 +1,24 @@
-import { assign } from '@ember/polyfills';
+/**
+ * Assign from @ember/polyfill, copied here to maintain compatilibity
+ * with Ember 3.x (and IE 11) as well as 5.x which drops this polyfill
+ * https://github.com/emberjs/ember.js/blob/744e536d37697aa59b19dcb4590593861b8eba5a/packages/%40ember/polyfills/lib/assign.ts
+ */
+function assign(target) {
+  for (let i = 1; i < arguments.length; i++) {
+    let arg = arguments[i];
+    if (!arg) {
+      continue;
+    }
+
+    let updates = Object.keys(arg);
+
+    for (let i = 0; i < updates.length; i++) {
+      let prop = updates[i];
+      target[prop] = arg[prop];
+    }
+  }
+
+  return target;
+}
 
 export default Object.assign || assign;


### PR DESCRIPTION
Copying this polyfill from ember maintains compatibility with IE 11 and Ember 3.x and allows this addon to be consumed by applications which use Ember 5.x where the assign polyfill has been removed.

This helps with addons that consume this addon where the canary scenario is currently failing with `Global error: Uncaught Error: Could not find module `@ember/polyfills` imported from `ember-simple-auth/utils/assign``