### PR TITLE
chore(deps): remove ember-export-application-global

### DIFF
--- a/packages/classic-test-app/package.json
+++ b/packages/classic-test-app/package.json
@@ -41,7 +41,6 @@
     "ember-data": "~4.4.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-engines": "^0.9.0",
-    "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^1.0.0",

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -50,7 +50,6 @@
     "ember-cli-terser": "4.0.2",
     "ember-cli-yuidoc": "^0.9.1",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^1.0.0",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -41,7 +41,6 @@
     "ember-data": "~4.4.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-engines": "^0.9.0",
-    "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5326,11 +5326,6 @@ ember-engines@^0.9.0:
     ember-cli-version-checker "^5.1.2"
     lodash "^4.17.11"
 
-ember-export-application-global@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
-  integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
-
 ember-factory-for-polyfill@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"


### PR DESCRIPTION
- removes `ember-export-application-global`
It appears to be unused as well as it breaks under newest ember