### PR TITLE
refactor(deprecation): use findRecord instead of find

### DIFF
--- a/packages/classic-test-app/app/routes/auth-error.js
+++ b/packages/classic-test-app/app/routes/auth-error.js
@@ -10,6 +10,6 @@ export default Route.extend({
   },
 
   model() {
-    return this.get('store').find('post', 3);
+    return this.get('store').findRecord('post', 3);
   }
 });

--- a/packages/classic-test-app/app/services/session-account.js
+++ b/packages/classic-test-app/app/services/session-account.js
@@ -7,7 +7,7 @@ export default Service.extend({
   async loadCurrentUser() {
     let accountId = this.get('session.data.authenticated.account_id');
     if (accountId) {
-      let account = await this.get('store').find('account', accountId);
+      let account = await this.get('store').findRecord('account', accountId);
       this.set('account', account);
     }
   }

--- a/packages/test-app/app/routes/auth-error.js
+++ b/packages/test-app/app/routes/auth-error.js
@@ -10,6 +10,6 @@ export default class AuthErrorRoute extends Route {
   }
 
   model() {
-    return this.store.find('post', 3);
+    return this.store.findRecord('post', 3);
   }
 }

--- a/packages/test-app/app/services/session-account.js
+++ b/packages/test-app/app/services/session-account.js
@@ -10,7 +10,7 @@ export default class SessionAccountService extends Service {
   async loadCurrentUser() {
     let accountId = this.session.data.authenticated.account_id;
     if (accountId) {
-      let account = await this.store.find('account', accountId);
+      let account = await this.store.findRecord('account', accountId);
       this.account = account;
     }
   }


### PR DESCRIPTION
- Fixes deprecation warning from ember-data.
`.find` is now deprecated

> {"type":"warn","text":"DEPRECATION: Using store.find is deprecated, use store.findRecord instead. Likely this means you are relying on the implicit store fetching behavior of routes unknowingly. [deprecation id: ember-data:deprecate-store-find] This will be removed in Ember 5.0.\n