### PR TITLE
chore(ci): fix removed tests step from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,15 +129,15 @@ jobs:
       - name: install dependencies
         run: yarn install
 
-      - name: tests
-        id: tests
+      - name: Allowed to fail tests
+        id: allowed_to_fail_tests
         run: yarn workspace ${{ matrix.workspace }} ${{ matrix.test-suite }}
         continue-on-error: true
 
       - uses: mainmatter/continue-on-error-comment@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          outcome: ${{ steps.tests.outcome }}
+          outcome: ${{ steps.allowed_to_fail_tests.outcome }}
           test-id: ${{ matrix.workspace }} ${{ matrix.test-suite }}
 
   extra-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: install dependencies
         run: yarn install
 
+      - name: tests
+        run: yarn workspace ${{ matrix.workspace }} ${{ matrix.test-suite }}
+        continue-on-error: ${{ matrix.allow-failure }}
 
   allow-fail-try-scenarios:
     name: ${{ matrix.workspace }} ${{ matrix.test-suite }} - Allowed to fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         id: yarn-cache
@@ -78,7 +78,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         id: yarn-cache
@@ -119,7 +119,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         id: yarn-cache
@@ -161,7 +161,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         id: yarn-cache
@@ -189,7 +189,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         id: yarn-cache


### PR DESCRIPTION
- Brings back mistakenly removed 'tests' step from the tests workflow 🙃 
https://github.com/mainmatter/ember-simple-auth/pull/2552

- Renames test step and changes ID.
It seemed to have overriden the other step called `tests` so our regular tests wouldn't run.

- Removes usage of ::set-output
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/