### PR TITLE
chore(tests): remove fastboot setup from classic-test-app

### DIFF
--- a/packages/classic-test-app/config/environment.js
+++ b/packages/classic-test-app/config/environment.js
@@ -42,10 +42,6 @@ module.exports = function(environment) {
     apiHost: 'http://localhost:4200',
 
     googleClientID: '694766332436-1g5bakjoo5flkfpv3t2mfsch9ghg7ggd.apps.googleusercontent.com',
-
-    fastboot: {
-      hostWhitelist: [/^localhost:\d+$/]
-    },
   };
 
   if (environment === 'development') {
@@ -70,9 +66,6 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     // put production settings here
-    ENV.fastboot = {
-      hostWhitelist: ['demo.ember-simple-auth.com', 'esa-demo.herokuapp.com']
-    };
     ENV.apiHost = 'https://demo-api.ember-simple-auth.com';
   }
 

--- a/packages/classic-test-app/package.json
+++ b/packages/classic-test-app/package.json
@@ -9,12 +9,10 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
-    "start:fastboot": "NODE_ENV=production node fastboot-server.js",
     "start:demo-api": "node server/demo-api.js",
     "test": "ember test",
     "test:all": "ember try:each",
-    "test:one": "ember try:one",
-    "test:fastboot": "ember fastboot:test"
+    "test:one": "ember try:one"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.22.10",
@@ -34,7 +32,6 @@
     "ember-cli-babel": "8.0.0",
     "ember-cli-content-security-policy": "1.1.1",
     "ember-cli-dependency-checker": "3.3.2",
-    "ember-cli-fastboot": "4.1.1",
     "ember-cli-htmlbars": "6.3.0",
     "ember-cli-inject-live-reload": "2.1.0",
     "ember-cli-sri": "2.1.1",
@@ -68,9 +65,6 @@
     "torii": "1.0.0-beta.2",
     "webpack": "5.88.2"
   },
-  "fastbootDependencies": [
-    "node-fetch"
-  ],
   "ember": {
     "edition": "octane"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       ember-cli-dependency-checker:
         specifier: 3.3.2
         version: 3.3.2(ember-cli@5.1.0)
-      ember-cli-fastboot:
-        specifier: 4.1.1
-        version: 4.1.1
       ember-cli-htmlbars:
         specifier: 6.3.0
         version: 6.3.0


### PR DESCRIPTION
This PR removes fastboot setup from the classic-test-app.
It doesn't run in fastboot context.