### PR TITLE
Remove IE 11 from browser targets

### DIFF
--- a/packages/classic-test-app/config/targets.js
+++ b/packages/classic-test-app/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions'
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers
 };

--- a/packages/ember-simple-auth/tests/dummy/config/targets.js
+++ b/packages/ember-simple-auth/tests/dummy/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions'
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers
 };

--- a/packages/test-app/config/targets.js
+++ b/packages/test-app/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions'
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers
 };


### PR DESCRIPTION
Removed IE 11 from test apps and "dummy" app which should resolve `emberBabel.extends` errors.

Possible fix for https://github.com/emberjs/ember.js/issues/20458

IE 11 support was dropped in Ember 4.0

