### PR TITLE
chore: fix fastboot testing environment for ember-data >= 4.12

### DIFF
--- a/packages/test-app/config/fastboot-testing.js
+++ b/packages/test-app/config/fastboot-testing.js
@@ -1,0 +1,17 @@
+/* global ReadableStream, WritableStream, TransformStream */
+module.exports = function() {
+  return {
+    buildSandboxGlobals(defaultGlobals) {
+      return Object.assign({}, defaultGlobals, {
+        AbortController,
+        ReadableStream:
+          typeof ReadableStream !== 'undefined' ? ReadableStream : require('node:stream/web').ReadableStream,
+        WritableStream:
+          typeof WritableStream !== 'undefined' ? WritableStream : require('node:stream/web').WritableStream,
+        TransformStream:
+          typeof TransformStream !== 'undefined' ? TransformStream : require('node:stream/web').TransformStream,
+        Headers: typeof Headers !== 'undefined' ? Headers : undefined,
+      });
+    },
+  };
+};

--- a/packages/test-app/config/fastboot.js
+++ b/packages/test-app/config/fastboot.js
@@ -1,0 +1,17 @@
+/* global ReadableStream, WritableStream, TransformStream */
+module.exports = function() {
+  return {
+    buildSandboxGlobals(defaultGlobals) {
+      return Object.assign({}, defaultGlobals, {
+        AbortController,
+        ReadableStream:
+          typeof ReadableStream !== 'undefined' ? ReadableStream : require('node:stream/web').ReadableStream,
+        WritableStream:
+          typeof WritableStream !== 'undefined' ? WritableStream : require('node:stream/web').WritableStream,
+        TransformStream:
+          typeof TransformStream !== 'undefined' ? TransformStream : require('node:stream/web').TransformStream,
+        Headers: typeof Headers !== 'undefined' ? Headers : undefined,
+      });
+    },
+  };
+};


### PR DESCRIPTION
- Fixed fastboot configuration as per https://github.com/ember-fastboot/ember-cli-fastboot/issues/913
https://github.com/emberjs/data/tree/b1c8aad0d14bfa360aa9a741d0b2e394dc30155b/tests/fastboot/config

`ember-data >= 4.12` seems to break under fastboot by default and need additional fastboot and fastboot-testing configuration.