### PR TITLE
Configure Renovate to update testing and fastboot stacks in the same PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,22 @@
 {
-  "extends": ["github>mainmatter/renovate-config:default.json5"]
+  "extends": ["github>mainmatter/renovate-config:default.json5"],
+  "packageRules": [
+    {
+      "groupName": "Ember Testing",
+      "matchPackageNames": [
+        "@ember/test-helpers",
+        "ember-qunit",
+        "qunit",
+        "qunit-dom",
+        "ember-try",
+      ],
+    },
+    {
+      "groupName": "Ember Fastboot",
+      "matchPackageNames": [
+        "ember-cli-fastboot",
+        "ember-cli-fastboot-testing",
+      ],
+    }
+  ]
 }


### PR DESCRIPTION
Inspired by the fact that often `ember-qunit`, `ember-test-helpers` depend on each other.