### PR TITLE
feat: Remove Torii from ember 5 scenarios

### DIFF
--- a/packages/ember-simple-auth/config/ember-try.js
+++ b/packages/ember-simple-auth/config/ember-try.js
@@ -103,11 +103,25 @@ module.exports = function() {
         {
           name: 'ember-default',
           npm: {
-            devDependencies: {}
+            devDependencies: {
+              torii: null,
+            }
           }
         },
-        embroiderSafe(),
-        embroiderOptimized()
+        embroiderSafe({
+          npm: {
+            devDependencies: {
+              torii: null,
+            }
+          }
+        }),
+        embroiderOptimized({
+          npm: {
+            devDependencies: {
+              torii: null,
+            }
+          }
+        })
       ]
     };
   });


### PR DESCRIPTION
- Torii is incompatible with Ember 5 and Embroider