### PR TITLE
chore(release): rename script to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: publish to npm
-        run: pnpm run --filter ember-simple-auth publish
+        run: pnpm run --filter ember-simple-auth release

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -25,7 +25,7 @@
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
     "prepack": "pnpm run build",
-    "publish": "npm publish"
+    "release": "npm publish"
   },
   "dependencies": {
     "@ember/test-waiters": "^3",


### PR DESCRIPTION
I didn't realize that "publish" is a lifecycle that also runs "npm publish". This caused release process to happen twice.
Which didn't break anything but caused npm to error out the second time.