### PR TITLE
Create store.js

### DIFF
--- a/packages/test-app/app/services/store.js
+++ b/packages/test-app/app/services/store.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data/store';

--- a/packages/test-app/app/transforms/string.js
+++ b/packages/test-app/app/transforms/string.js
@@ -1,0 +1,1 @@
+export { StringTransform as default } from '@ember-data/serializer/transform';


### PR DESCRIPTION
Explicitly define store, to suppress deprecation warning, which appeared after logging in.

```
DEPRECATION: You are relying on ember-data auto-magically installing the store service. Use `export { default } from 'ember-data/store\';` in app/services/store.js instead [deprecation id: ember-data:deprecate-legacy-imports] This will be removed in ember-data 6.0.
```