### PR TITLE
Revert "chore(ci): allow mainmatter/continue-on-error-comment to work on forks"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       pull-requests: write
-      issues: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Reverts mainmatter/ember-simple-auth#2797