### PR TITLE
chore(docs): move events to an internal session

### DIFF
--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -7,7 +7,42 @@ import { debug, assert } from '@ember/debug';
 import { getOwner, setOwner } from '@ember/application';
 import { isTesting } from '@embroider/macros';
 
+/**
+  __An internal implementation of Session. Communicates with stores and emits events.__
+
+  @class InternalSession
+  @extends ObjectProxy
+  @private
+*/
+
 export default ObjectProxy.extend(Evented, {
+  /**
+    Triggered whenever the session is successfully authenticated. This happens
+    when the session gets authenticated via
+    {@linkplain SessionService.authenticate} but also
+    when the session is authenticated in another tab or window of the same
+    application and the session state gets synchronized across tabs or windows
+    via the store (see
+    {@linkplain BaseStore.sessionDataUpdated}).
+
+    @memberof InternalSession
+    @event authenticationSucceeded
+    @private
+  */
+
+  /**
+    Triggered whenever the session is successfully invalidated. This happens
+    when the session gets invalidated via
+    {@linkplain SessionService.invalidate} but also
+    when the session is invalidated in another tab or window of the same
+    application and the session state gets synchronized across tabs or windows
+    via the store (see
+    {@linkplain BaseStore.sessionDataUpdated}.
+
+    @memberof InternalSession
+    @event invalidationSucceeded
+    @private
+  */
   authenticator: null,
   store: null,
   isAuthenticated: false,

--- a/packages/ember-simple-auth/src/services/session.js
+++ b/packages/ember-simple-auth/src/services/session.js
@@ -44,34 +44,6 @@ function assertSetupHasBeenCalled(isSetupCalled) {
 */
 export default Service.extend({
   /**
-    Triggered whenever the session is successfully authenticated. This happens
-    when the session gets authenticated via
-    {@linkplain SessionService.authenticate} but also
-    when the session is authenticated in another tab or window of the same
-    application and the session state gets synchronized across tabs or windows
-    via the store (see
-    {@linkplain BaseStore.sessionDataUpdated}).
-
-    @memberof SessionService
-    @event authenticationSucceeded
-    @public
-  */
-
-  /**
-    Triggered whenever the session is successfully invalidated. This happens
-    when the session gets invalidated via
-    {@linkplain SessionService.invalidate} but also
-    when the session is invalidated in another tab or window of the same
-    application and the session state gets synchronized across tabs or windows
-    via the store (see
-    {@linkplain BaseStore.sessionDataUpdated}.
-
-    @memberof SessionService
-    @event invalidationSucceeded
-    @public
-  */
-
-  /**
     Returns whether the session is currently authenticated.
 
     @memberof SessionService


### PR DESCRIPTION
- Moves `authenticationSucceeded` and `invalidationSucceeded` event documentation to the InternalSession instead, since it's the one that emits them.

As pointed out [here](https://github.com/mainmatter/ember-simple-auth/pull/2526#issuecomment-2323538557), these events are still documented as members of ESA's SessionService while it actually only uses the internal session events.
