### PR TITLE
chore(release): fix release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
       - master
 
 concurrency:


### PR DESCRIPTION
Mistakenly pushed 9be5965769ce81fa06e5f0ac1c5022980118574b without a PR which didn't trigger a re-release.

The problem is that the publish workflow wasn't properly authorized.