### PR TITLE
Expire cookie if RememberMe button is off (again)

### DIFF
--- a/packages/test-app/app/components/login-form.js
+++ b/packages/test-app/app/components/login-form.js
@@ -20,6 +20,8 @@ export default class LoginFormComponent extends Component {
 
       if (this.rememberMe) {
         this.session.set('store.cookieExpirationTime', 60 * 60 * 24 * 14);
+      } else {
+        this.session.set('store.cookieExpirationTime', null);
       }
     } catch (response) {
       let responseBody = await response.clone().json();


### PR DESCRIPTION
I noticed different behavior: logging in with RememberMe button switched off, does not generate a cookieExpirationTime. Logging in with the button switch on, generates an expiration time. However, switching it off (again) does not reset the expiration time. This PR will make it consistent.