### PR TITLE
feat: Use native promises, remove RSVP

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
   "volta": {
     "node": "20.10.0",
     "pnpm": "9.11.0"
-  }
+  },
+  "packageManager": "pnpm@9.11.0"
 }

--- a/packages/ember-simple-auth/src/authenticators/base.js
+++ b/packages/ember-simple-auth/src/authenticators/base.js
@@ -1,4 +1,3 @@
-import RSVP from 'rsvp';
 import Evented from '@ember/object/evented';
 import EmberObject from '@ember/object';
 
@@ -104,12 +103,12 @@ export default EmberObject.extend(Evented, {
     @memberof BaseAuthenticator
     @method restore
     @param {Object} data The data to restore the session from
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming or remaining authenticated
+    @return {Promise} A promise that when it resolves results in the session becoming or remaining authenticated
     @member
     @public
   */
   restore() {
-    return RSVP.reject();
+    return Promise.reject();
   },
 
   /**
@@ -133,12 +132,12 @@ export default EmberObject.extend(Evented, {
     @memberof BaseAuthenticator
     @method authenticate
     @param {Any} [...args] The arguments that the authenticator requires to authenticate the session
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated
+    @return {Promise} A promise that when it resolves results in the session becoming authenticated
     @member
     @public
   */
   authenticate() {
-    return RSVP.reject();
+    return Promise.reject();
   },
 
   /**
@@ -158,11 +157,11 @@ export default EmberObject.extend(Evented, {
     @method invalidate
     @param {Object} data The current authenticated session data
     @param {Array} ...args additional arguments as required by the authenticator
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being invalidated
+    @return {Promise} A promise that when it resolves results in the session being invalidated
     @member
     @public
   */
   invalidate() {
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 });

--- a/packages/ember-simple-auth/src/authenticators/devise.js
+++ b/packages/ember-simple-auth/src/authenticators/devise.js
@@ -1,4 +1,3 @@
-import { Promise } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { run } from '@ember/runloop';
 import BaseAuthenticator from './base';
@@ -77,7 +76,7 @@ export default BaseAuthenticator.extend({
     @memberof DeviseAuthenticator
     @method restore
     @param {Object} data The data to restore the session from
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming or remaining authenticated
+    @return {Promise} A promise that when it resolves results in the session becoming or remaining authenticated
     @public
   */
   restore(data) {
@@ -101,7 +100,7 @@ export default BaseAuthenticator.extend({
     @method authenticate
     @param {String} identification The user's identification
     @param {String} password The user's password
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated. If authentication fails, the promise will reject with the server response; however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
+    @return {Promise} A promise that when it resolves results in the session becoming authenticated. If authentication fails, the promise will reject with the server response; however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
     @public
   */
   authenticate(identification, password) {
@@ -144,7 +143,7 @@ export default BaseAuthenticator.extend({
 
     @memberof DeviseAuthenticator
     @method invalidate
-    @return {Ember.RSVP.Promise} A resolving promise
+    @return {Promise} A resolving promise
     @public
   */
   invalidate() {

--- a/packages/ember-simple-auth/src/authenticators/oauth2-implicit-grant.js
+++ b/packages/ember-simple-auth/src/authenticators/oauth2-implicit-grant.js
@@ -1,6 +1,5 @@
 /** @module ember-simple-auth/authenticators/oauth2-implicit-grant **/
 
-import RSVP from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import BaseAuthenticator from './base';
 /**
@@ -52,11 +51,11 @@ export default BaseAuthenticator.extend({
    @memberof OAuth2ImplicitGrantAuthenticator
    @method restore
    @param {Object} data The data to restore the session from
-   @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming or remaining authenticated
+   @return {Promise} A promise that when it resolves results in the session becoming or remaining authenticated
    @public
    */
   restore(data) {
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (!this._validateData(data)) {
         return reject('Could not restore session - "access_token" missing.');
       }
@@ -77,11 +76,11 @@ export default BaseAuthenticator.extend({
    @memberof OAuth2ImplicitGrantAuthenticator
    @method authenticate
    @param {Object} hash The location hash
-   @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated
+   @return {Promise} A promise that when it resolves results in the session becoming authenticated
    @public
    */
   authenticate(hash) {
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (hash.error) {
         reject(hash.error);
       } else if (!this._validateData(hash)) {
@@ -97,11 +96,11 @@ export default BaseAuthenticator.extend({
 
    @memberof OAuth2ImplicitGrantAuthenticator
    @method invalidate
-   @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being invalidated
+   @return {Promise} A promise that when it resolves results in the session being invalidated
    @public
    */
   invalidate() {
-    return RSVP.Promise.resolve();
+    return Promise.resolve();
   },
 
   _validateData(data) {

--- a/packages/ember-simple-auth/src/authenticators/oauth2-password-grant.js
+++ b/packages/ember-simple-auth/src/authenticators/oauth2-password-grant.js
@@ -1,4 +1,3 @@
-import RSVP from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { run, later, cancel } from '@ember/runloop';
 import { A, makeArray } from '@ember/array';
@@ -142,11 +141,11 @@ export default BaseAuthenticator.extend({
     @memberof OAuth2PasswordGrantAuthenticator
     @method restore
     @param {Object} data The data to restore the session from
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming or remaining authenticated. If restoration fails, the promise will reject with the server response (in case the access token had expired and was refreshed using a refresh token); however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
+    @return {Promise} A promise that when it resolves results in the session becoming or remaining authenticated. If restoration fails, the promise will reject with the server response (in case the access token had expired and was refreshed using a refresh token); however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
     @public
   */
   restore(data) {
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const now = new Date().getTime();
       const refreshAccessTokens = this.get('refreshAccessTokens');
       if (!isEmpty(data['expires_at']) && data['expires_at'] < now) {
@@ -226,11 +225,11 @@ export default BaseAuthenticator.extend({
     @param {String} password The resource owner password
     @param {String|Array} scope The scope of the access request (see [RFC 6749, section 3.3](http://tools.ietf.org/html/rfc6749#section-3.3))
     @param {Object} headers Optional headers that particular backends may require (for example sending 2FA challenge responses)
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated. If authentication fails, the promise will reject with the server response; however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
+    @return {Promise} A promise that when it resolves results in the session becoming authenticated. If authentication fails, the promise will reject with the server response; however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
     @public
   */
   authenticate(identification, password, scope = [], headers = {}) {
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const data = { grant_type: 'password', username: identification, password };
       const serverTokenEndpoint = this.get('serverTokenEndpoint');
 
@@ -277,7 +276,7 @@ export default BaseAuthenticator.extend({
     @memberof OAuth2PasswordGrantAuthenticator
     @method invalidate
     @param {Object} data The current authenticated session data
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being invalidated. If invalidation fails, the promise will reject with the server response (in case token revocation is used); however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
+    @return {Promise} A promise that when it resolves results in the session being invalidated. If invalidation fails, the promise will reject with the server response (in case token revocation is used); however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
     @public
   */
   invalidate(data) {
@@ -287,7 +286,7 @@ export default BaseAuthenticator.extend({
       delete this._refreshTokenTimeout;
       resolve();
     }
-    return new RSVP.Promise(resolve => {
+    return new Promise(resolve => {
       if (isEmpty(serverTokenRevocationEndpoint)) {
         success.apply(this, [resolve]);
       } else {
@@ -306,7 +305,7 @@ export default BaseAuthenticator.extend({
         const succeed = () => {
           success.apply(this, [resolve]);
         };
-        RSVP.all(requests).then(succeed, succeed);
+        Promise.all(requests).then(succeed, succeed);
       }
     });
   },
@@ -342,7 +341,7 @@ export default BaseAuthenticator.extend({
       method: 'POST',
     };
 
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       fetch(url, options)
         .then(response => {
           response.text().then(text => {
@@ -396,7 +395,7 @@ export default BaseAuthenticator.extend({
     }
 
     const serverTokenEndpoint = this.get('serverTokenEndpoint');
-    return new RSVP.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       this.makeRequest(serverTokenEndpoint, data).then(
         response => {
           run(() => {

--- a/packages/ember-simple-auth/src/authenticators/test.js
+++ b/packages/ember-simple-auth/src/authenticators/test.js
@@ -1,16 +1,15 @@
-import RSVP from 'rsvp';
 import BaseAuthenticator from './base';
 
 export default BaseAuthenticator.extend({
   restore(data) {
-    return RSVP.resolve(data);
+    return Promise.resolve(data);
   },
 
   authenticate(data) {
-    return RSVP.resolve(data);
+    return Promise.resolve(data);
   },
 
   invalidate() {
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 });

--- a/packages/ember-simple-auth/src/authenticators/torii.js
+++ b/packages/ember-simple-auth/src/authenticators/torii.js
@@ -1,4 +1,3 @@
-import RSVP from 'rsvp';
 import { assert, deprecate } from '@ember/debug';
 import { isPresent, isEmpty } from '@ember/utils';
 import BaseAuthenticator from './base';
@@ -59,7 +58,7 @@ export default BaseAuthenticator.extend({
     @memberof ToriiAuthenticator
     @method restore
     @param {Object} data The data to restore the session from
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming or remaining authenticated
+    @return {Promise} A promise that when it resolves results in the session becoming or remaining authenticated
     @public
   */
   restore(data) {
@@ -83,7 +82,7 @@ export default BaseAuthenticator.extend({
         );
     } else {
       delete this._provider;
-      return RSVP.reject();
+      return Promise.reject();
     }
   },
 
@@ -98,7 +97,7 @@ export default BaseAuthenticator.extend({
     @method authenticate
     @param {String} provider The torii provider to authenticate the session with
     @param {Object} options The options to pass to the torii provider
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated
+    @return {Promise} A promise that when it resolves results in the session becoming authenticated
     @public
   */
   authenticate(provider, options) {
@@ -119,7 +118,7 @@ export default BaseAuthenticator.extend({
 
     @memberof ToriiAuthenticator
     @method invalidate
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being invalidated
+    @return {Promise} A promise that when it resolves results in the session being invalidated
     @public
   */
   invalidate(data) {

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -1,4 +1,3 @@
-import RSVP from 'rsvp';
 import { isEmpty, isNone } from '@ember/utils';
 import ObjectProxy from '@ember/object/proxy';
 import Evented from '@ember/object/evented';
@@ -75,7 +74,7 @@ export default ObjectProxy.extend(Evented, {
         return this._setup(authenticatorFactory, content, true);
       },
       error => {
-        const rejectWithError = () => RSVP.Promise.reject(error);
+        const rejectWithError = () => Promise.reject(error);
 
         this._busy = false;
         return this._clear().then(rejectWithError, rejectWithError);
@@ -89,7 +88,7 @@ export default ObjectProxy.extend(Evented, {
 
     if (!this.get('isAuthenticated')) {
       this._busy = false;
-      return RSVP.Promise.resolve();
+      return Promise.resolve();
     }
 
     let authenticator = this._lookupAuthenticator(this.authenticator);
@@ -102,14 +101,14 @@ export default ObjectProxy.extend(Evented, {
       error => {
         this.trigger('sessionInvalidationFailed', error);
         this._busy = false;
-        return RSVP.Promise.reject(error);
+        return Promise.reject(error);
       }
     );
   },
 
   restore() {
     this._busy = true;
-    const reject = () => RSVP.Promise.reject();
+    const reject = () => Promise.reject();
 
     return this.store.restore().then(
       restoredContent => {

--- a/packages/ember-simple-auth/src/services/session.js
+++ b/packages/ember-simple-auth/src/services/session.js
@@ -150,7 +150,7 @@ export default Service.extend({
     @method authenticate
     @param {String} authenticator The authenticator to use to authenticate the session
     @param {Any} [...args] The arguments to pass to the authenticator; depending on the type of authenticator these might be a set of credentials, a Facebook OAuth Token, etc.
-    @return {RSVP.Promise} A promise that resolves when the session was authenticated successfully and rejects otherwise
+    @return {Promise} A promise that resolves when the session was authenticated successfully and rejects otherwise
     @public
   */
   authenticate() {
@@ -184,7 +184,7 @@ export default Service.extend({
     @memberof SessionService
     @method invalidate
     @param {Array} ...args arguments that will be passed to the authenticator
-    @return {RSVP.Promise} A promise that resolves when the session was invalidated successfully and rejects otherwise
+    @return {Promise} A promise that resolves when the session was invalidated successfully and rejects otherwise
     @public
   */
   invalidate() {

--- a/packages/ember-simple-auth/src/session-stores/adaptive.js
+++ b/packages/ember-simple-auth/src/session-stores/adaptive.js
@@ -204,7 +204,7 @@ export default Base.extend({
     @memberof AdaptiveStore
     @method persist
     @param {Object} data The data to persist
-    @return {Ember.RSVP.Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
+    @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
   persist() {
@@ -217,7 +217,7 @@ export default Base.extend({
 
     @memberof AdaptiveStore
     @method restore
-    @return {Ember.RSVP.Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
+    @return {Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
     @public
   */
   restore() {
@@ -231,7 +231,7 @@ export default Base.extend({
 
     @memberof AdaptiveStore
     @method clear
-    @return {Ember.RSVP.Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
+    @return {Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
     @public
   */
   clear() {

--- a/packages/ember-simple-auth/src/session-stores/base.js
+++ b/packages/ember-simple-auth/src/session-stores/base.js
@@ -1,4 +1,3 @@
-import RSVP from 'rsvp';
 import EmberObject from '@ember/object';
 import Evented from '@ember/object/evented';
 
@@ -37,11 +36,11 @@ export default EmberObject.extend(Evented, {
     @memberof BaseStore
     @method persist
     @param {Object} data The data to persist
-    @return {Ember.RSVP.Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
+    @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
   persist() {
-    return RSVP.reject();
+    return Promise.reject();
   },
 
   /**
@@ -52,11 +51,11 @@ export default EmberObject.extend(Evented, {
 
     @memberof BaseStore
     @method restore
-    @return {Ember.RSVP.Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
+    @return {Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
     @public
   */
   restore() {
-    return RSVP.reject();
+    return Promise.reject();
   },
 
   /**
@@ -67,10 +66,10 @@ export default EmberObject.extend(Evented, {
 
     @memberof BaseStore
     @method clear
-    @return {Ember.RSVP.Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
+    @return {Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
     @public
   */
   clear() {
-    return RSVP.reject();
+    return Promise.reject();
   },
 });

--- a/packages/ember-simple-auth/src/session-stores/cookie.js
+++ b/packages/ember-simple-auth/src/session-stores/cookie.js
@@ -1,4 +1,3 @@
-import RSVP from 'rsvp';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { later, cancel, scheduleOnce, next } from '@ember/runloop';
@@ -227,7 +226,7 @@ export default BaseStore.extend({
     @memberof CookieStore
     @method persist
     @param {Object} data The data to persist
-    @return {RSVP.Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
+    @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
   persist(data) {
@@ -235,7 +234,7 @@ export default BaseStore.extend({
     data = JSON.stringify(data || {});
     let expiration = this._calculateExpirationTime();
     this._write(data, expiration);
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 
   /**
@@ -243,15 +242,15 @@ export default BaseStore.extend({
 
     @memberof CookieStore
     @method restore
-    @return {RSVP.Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
+    @return {Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
     @public
   */
   restore() {
     let data = this._read(this.get('cookieName'));
     if (isEmpty(data)) {
-      return RSVP.resolve({});
+      return Promise.resolve({});
     } else {
-      return RSVP.resolve(JSON.parse(data));
+      return Promise.resolve(JSON.parse(data));
     }
   },
 
@@ -260,13 +259,13 @@ export default BaseStore.extend({
 
     @memberof CookieStore
     @method clear
-    @return {RSVP.Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
+    @return {Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
     @public
   */
   clear() {
     this._write('', 0);
     this._lastData = {};
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 
   _read(name) {
@@ -341,7 +340,7 @@ export default BaseStore.extend({
     if (this._isPageVisible()) {
       return this._renew();
     } else {
-      return RSVP.resolve();
+      return Promise.resolve();
     }
   },
 

--- a/packages/ember-simple-auth/src/session-stores/ephemeral.js
+++ b/packages/ember-simple-auth/src/session-stores/ephemeral.js
@@ -1,4 +1,3 @@
-import RSVP from 'rsvp';
 import BaseStore from './base';
 
 /**
@@ -23,13 +22,13 @@ export default BaseStore.extend({
     @memberof EpemeralStore
     @method persist
     @param {Object} data The data to persist
-    @return {Ember.RSVP.Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
+    @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
   persist(data) {
     this._data = JSON.stringify(data || {});
 
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 
   /**
@@ -37,13 +36,13 @@ export default BaseStore.extend({
 
     @memberof EpemeralStore
     @method restore
-    @return {Ember.RSVP.Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
+    @return {Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
     @public
   */
   restore() {
     const data = JSON.parse(this._data) || {};
 
-    return RSVP.resolve(data);
+    return Promise.resolve(data);
   },
 
   /**
@@ -51,13 +50,13 @@ export default BaseStore.extend({
 
     @memberof EpemeralStore
     @method clear
-    @return {Ember.RSVP.Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
+    @return {Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
     @public
   */
   clear() {
     delete this._data;
     this._data = '{}';
 
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 });

--- a/packages/ember-simple-auth/src/session-stores/local-storage.js
+++ b/packages/ember-simple-auth/src/session-stores/local-storage.js
@@ -1,5 +1,3 @@
-import RSVP from 'rsvp';
-
 import { bind } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import BaseStore from './base';
@@ -60,7 +58,7 @@ export default BaseStore.extend({
     @memberof LocalStorageStore
     @method persist
     @param {Object} data The data to persist
-    @return {Ember.RSVP.Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
+    @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
   persist(data) {
@@ -68,7 +66,7 @@ export default BaseStore.extend({
     data = JSON.stringify(data || {});
     localStorage.setItem(this.key, data);
 
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 
   /**
@@ -76,13 +74,13 @@ export default BaseStore.extend({
 
     @memberof LocalStorageStore
     @method restore
-    @return {Ember.RSVP.Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
+    @return {Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
     @public
   */
   restore() {
     let data = localStorage.getItem(this.key);
 
-    return RSVP.resolve(JSON.parse(data) || {});
+    return Promise.resolve(JSON.parse(data) || {});
   },
 
   /**
@@ -92,14 +90,14 @@ export default BaseStore.extend({
 
     @memberof LocalStorageStore
     @method clear
-    @return {Ember.RSVP.Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
+    @return {Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
     @public
   */
   clear() {
     localStorage.removeItem(this.key);
     this._lastData = {};
 
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 
   _handleStorageEvent(e) {

--- a/packages/ember-simple-auth/src/session-stores/session-storage.js
+++ b/packages/ember-simple-auth/src/session-stores/session-storage.js
@@ -1,5 +1,3 @@
-import RSVP from 'rsvp';
-
 import { bind } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import BaseStore from './base';
@@ -55,7 +53,7 @@ export default BaseStore.extend({
     @memberof SessionStorageStore
     @method persist
     @param {Object} data The data to persist
-    @return {Ember.RSVP.Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
+    @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
   persist(data) {
@@ -63,7 +61,7 @@ export default BaseStore.extend({
     data = JSON.stringify(data || {});
     sessionStorage.setItem(this.key, data);
 
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 
   /**
@@ -71,13 +69,13 @@ export default BaseStore.extend({
 
     @memberof SessionStorageStore
     @method restore
-    @return {Ember.RSVP.Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
+    @return {Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
     @public
   */
   restore() {
     let data = sessionStorage.getItem(this.key);
 
-    return RSVP.resolve(JSON.parse(data) || {});
+    return Promise.resolve(JSON.parse(data) || {});
   },
 
   /**
@@ -87,14 +85,14 @@ export default BaseStore.extend({
 
     @memberof SessionStorageStore
     @method clear
-    @return {Ember.RSVP.Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
+    @return {Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
     @public
   */
   clear() {
     sessionStorage.removeItem(this.key);
     this._lastData = {};
 
-    return RSVP.resolve();
+    return Promise.resolve();
   },
 
   _handleStorageEvent(e) {

--- a/packages/ember-simple-auth/src/test-support/index.js
+++ b/packages/ember-simple-auth/src/test-support/index.js
@@ -1,6 +1,5 @@
 import { get } from '@ember/object';
 import { getContext, settled } from '@ember/test-helpers';
-import Promise from 'rsvp';
 import Test from '../authenticators/test';
 
 const SESSION_SERVICE_KEY = 'service:session';

--- a/packages/test-esa/tests/unit/authenticators/torii-test.js
+++ b/packages/test-esa/tests/unit/authenticators/torii-test.js
@@ -1,4 +1,3 @@
-import RSVP from 'rsvp';
 import { module, test } from 'qunit';
 import sinonjs from 'sinon';
 import Torii from 'ember-simple-auth/authenticators/torii';
@@ -50,7 +49,7 @@ module('ToriiAuthenticator', function (hooks) {
     module('when there is a torii provider in the session data', function () {
       module('when torii fetches successfully', function (hooks) {
         hooks.beforeEach(function () {
-          sinon.stub(torii, 'fetch').returns(RSVP.resolve({ some: 'other data' }));
+          sinon.stub(torii, 'fetch').resolves({ some: 'other data' });
         });
 
         test('returns a promise that resolves with the session data merged with the data fetched from torri', async function (assert) {
@@ -66,7 +65,7 @@ module('ToriiAuthenticator', function (hooks) {
 
       module('when torii does not fetch successfully', function (hooks) {
         hooks.beforeEach(function () {
-          sinon.stub(torii, 'fetch').returns(RSVP.reject());
+          sinon.stub(torii, 'fetch').rejects();
         });
 
         itDoesNotRestore({ some: 'data', provider: 'provider' });
@@ -93,7 +92,7 @@ module('ToriiAuthenticator', function (hooks) {
 
     module('when torii opens successfully', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(torii, 'open').returns(RSVP.resolve({ some: 'data' }));
+        sinon.stub(torii, 'open').resolves({ some: 'data' });
       });
 
       test('returns a promise that resolves with the session data', async function (assert) {
@@ -105,7 +104,7 @@ module('ToriiAuthenticator', function (hooks) {
 
     module('when torii does not open successfully', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(torii, 'open').returns(RSVP.reject());
+        sinon.stub(torii, 'open').rejects();
       });
 
       test('returns a rejecting promise', async function (assert) {
@@ -123,7 +122,7 @@ module('ToriiAuthenticator', function (hooks) {
   module('#invalidate', function () {
     module('when torii closes successfully', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(torii, 'close').returns(RSVP.resolve());
+        sinon.stub(torii, 'close').resolves();
       });
 
       test('returns a resolving promise', async function (assert) {
@@ -139,7 +138,7 @@ module('ToriiAuthenticator', function (hooks) {
 
     module('when torii does not close successfully', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(torii, 'close').returns(RSVP.reject());
+        sinon.stub(torii, 'close').rejects();
       });
 
       test('returns a rejecting promise', async function (assert) {

--- a/packages/test-esa/tests/unit/internal-session-test.js
+++ b/packages/test-esa/tests/unit/internal-session-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import RSVP from 'rsvp';
 import { next } from '@ember/runloop';
 import sinonjs from 'sinon';
 import Authenticator from 'ember-simple-auth/authenticators/base';
@@ -161,7 +160,7 @@ module('InternalSession', function (hooks) {
 
       module('when the authenticator resolves restoration', function (hooks) {
         hooks.beforeEach(function () {
-          sinon.stub(authenticator, 'restore').returns(RSVP.resolve({ some: 'property' }));
+          sinon.stub(authenticator, 'restore').returns(Promise.resolve({ some: 'property' }));
         });
 
         test('returns a resolving promise', async function (assert) {
@@ -231,7 +230,7 @@ module('InternalSession', function (hooks) {
 
       module('when the authenticator rejects restoration', function (hooks) {
         hooks.beforeEach(function () {
-          sinon.stub(authenticator, 'restore').returns(RSVP.reject());
+          sinon.stub(authenticator, 'restore').rejects();
         });
 
         itDoesNotRestore();
@@ -244,7 +243,7 @@ module('InternalSession', function (hooks) {
 
     module('when the store rejects restoration', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(store, 'restore').returns(RSVP.Promise.reject());
+        sinon.stub(store, 'restore').rejects();
       });
 
       test('is not authenticated', async function (assert) {
@@ -259,7 +258,7 @@ module('InternalSession', function (hooks) {
 
     module('when the store rejects persistance', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(store, 'persist').returns(RSVP.reject());
+        sinon.stub(store, 'persist').rejects();
       });
 
       test('is not authenticated', async function (assert) {
@@ -276,7 +275,7 @@ module('InternalSession', function (hooks) {
   module('authentication', function () {
     module('when the authenticator resolves authentication', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(authenticator, 'authenticate').returns(RSVP.resolve({ some: 'property' }));
+        sinon.stub(authenticator, 'authenticate').resolves({ some: 'property' });
       });
 
       test('it throws when the provided authenticator could not be found', function (assert) {
@@ -345,7 +344,7 @@ module('InternalSession', function (hooks) {
     module('when the authenticator rejects authentication', function () {
       test('is not authenticated', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'authenticate').returns(RSVP.reject('error auth'));
+        sinon.stub(authenticator, 'authenticate').rejects('error auth');
 
         try {
           await session.authenticate('authenticator:test');
@@ -356,7 +355,7 @@ module('InternalSession', function (hooks) {
 
       test('returns a rejecting promise', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'authenticate').returns(RSVP.reject('error auth'));
+        sinon.stub(authenticator, 'authenticate').rejects('error auth');
 
         try {
           await session.authenticate('authenticator:test');
@@ -368,7 +367,7 @@ module('InternalSession', function (hooks) {
 
       test('clears its authenticated section', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'authenticate').returns(RSVP.reject('error auth'));
+        sinon.stub(authenticator, 'authenticate').rejects('error auth');
         session.set('content', { some: 'property', authenticated: { some: 'other property' } });
 
         try {
@@ -380,7 +379,7 @@ module('InternalSession', function (hooks) {
 
       test('updates the store', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'authenticate').returns(RSVP.reject('error auth'));
+        sinon.stub(authenticator, 'authenticate').rejects('error auth');
         session.set('content', { some: 'property', authenticated: { some: 'other property' } });
 
         try {
@@ -395,7 +394,7 @@ module('InternalSession', function (hooks) {
       test('does not trigger the "authenticationSucceeded" event', async function (assert) {
         assert.expect(1);
         let triggered = false;
-        sinon.stub(authenticator, 'authenticate').returns(RSVP.reject('error auth'));
+        sinon.stub(authenticator, 'authenticate').rejects('error auth');
         session.one('authenticationSucceeded', () => (triggered = true));
 
         try {
@@ -408,7 +407,7 @@ module('InternalSession', function (hooks) {
 
     module('when the store rejects persistance', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(store, 'persist').returns(RSVP.reject());
+        sinon.stub(store, 'persist').rejects();
       });
 
       test('is not authenticated', async function (assert) {
@@ -424,7 +423,7 @@ module('InternalSession', function (hooks) {
 
   module('invalidation', function (hooks) {
     hooks.beforeEach(async function () {
-      sinon.stub(authenticator, 'authenticate').returns(RSVP.resolve({ some: 'property' }));
+      sinon.stub(authenticator, 'authenticate').resolves({ some: 'property' });
       await session.authenticate('authenticator:test');
     });
 
@@ -449,7 +448,7 @@ module('InternalSession', function (hooks) {
 
     module('when the authenticator resolves invalidation', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(authenticator, 'invalidate').returns(RSVP.resolve());
+        sinon.stub(authenticator, 'invalidate').resolves();
       });
 
       test('is not authenticated', async function (assert) {
@@ -498,7 +497,7 @@ module('InternalSession', function (hooks) {
     module('when the authenticator rejects invalidation', function () {
       test('stays authenticated', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'invalidate').returns(RSVP.reject('error'));
+        sinon.stub(authenticator, 'invalidate').rejects('error');
 
         try {
           await session.invalidate();
@@ -509,7 +508,7 @@ module('InternalSession', function (hooks) {
 
       test('returns a rejecting promise', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'invalidate').returns(RSVP.reject('error'));
+        sinon.stub(authenticator, 'invalidate').rejects('error');
 
         try {
           await session.invalidate();
@@ -521,7 +520,7 @@ module('InternalSession', function (hooks) {
 
       test('keeps its content', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'invalidate').returns(RSVP.reject('error'));
+        sinon.stub(authenticator, 'invalidate').rejects('error');
 
         try {
           await session.invalidate();
@@ -535,7 +534,7 @@ module('InternalSession', function (hooks) {
 
       test('does not update the store', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'invalidate').returns(RSVP.reject('error'));
+        sinon.stub(authenticator, 'invalidate').rejects('error');
 
         try {
           await session.invalidate();
@@ -550,7 +549,7 @@ module('InternalSession', function (hooks) {
 
       test('does not trigger the "invalidationSucceeded" event', async function (assert) {
         assert.expect(1);
-        sinon.stub(authenticator, 'invalidate').returns(RSVP.reject('error'));
+        sinon.stub(authenticator, 'invalidate').rejects('error');
         let triggered = false;
         session.one('invalidationSucceeded', () => (triggered = true));
 
@@ -566,7 +565,7 @@ module('InternalSession', function (hooks) {
 
     module('when the store rejects persistance', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(store, 'persist').returns(RSVP.reject());
+        sinon.stub(store, 'persist').rejects();
       });
 
       test('rejects but is not authenticated', async function (assert) {
@@ -633,7 +632,7 @@ module('InternalSession', function (hooks) {
     module('when the session is currently busy', function (hooks) {
       hooks.beforeEach(function () {
         sinon.stub(store, 'restore').returns(
-          new RSVP.Promise(resolve => {
+          new Promise(resolve => {
             next(() => resolve({ some: 'other property' }));
           })
         );
@@ -659,7 +658,7 @@ module('InternalSession', function (hooks) {
       module('when there is an authenticator factory in the event data', function () {
         module('when the authenticator resolves restoration', function (hooks) {
           hooks.beforeEach(function () {
-            sinon.stub(authenticator, 'restore').returns(RSVP.resolve({ some: 'other property' }));
+            sinon.stub(authenticator, 'restore').resolves({ some: 'other property' });
           });
 
           test('is authenticated', async function (assert) {
@@ -765,7 +764,7 @@ module('InternalSession', function (hooks) {
 
         module('when the authenticator rejects restoration', function (hooks) {
           hooks.beforeEach(function () {
-            sinon.stub(authenticator, 'restore').returns(RSVP.reject());
+            sinon.stub(authenticator, 'restore').rejects();
           });
 
           test('is not authenticated', async function (assert) {

--- a/packages/test-esa/tests/unit/services/session-test.js
+++ b/packages/test-esa/tests/unit/services/session-test.js
@@ -3,7 +3,6 @@ import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
 import EmberObject, { set } from '@ember/object';
 import sinonjs from 'sinon';
-import RSVP from 'rsvp';
 
 module('SessionService', function (hooks) {
   setupTest(hooks);
@@ -502,7 +501,7 @@ module('SessionService', function (hooks) {
     test("doesn't raise an error when restore rejects", async function (assert) {
       assert.expect(1);
       sinon.stub(sessionService, '_setupHandlers');
-      sinon.stub(session, 'restore').returns(RSVP.reject());
+      sinon.stub(session, 'restore').rejects();
 
       try {
         await sessionService.setup();

--- a/packages/test-esa/tests/unit/session-stores/shared/storage-event-handler-behavior.js
+++ b/packages/test-esa/tests/unit/session-stores/shared/storage-event-handler-behavior.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { run } from '@ember/runloop';
 import sinonjs from 'sinon';
+import { settled } from '@ember/test-helpers';
 
 export default function (options) {
   let sinon;
@@ -33,18 +34,19 @@ export default function (options) {
       assert.ok(window.addEventListener.calledOnce);
     });
 
-    test('triggers the "sessionDataUpdated" event when the data in the browser storage has changed', function (assert) {
+    test('triggers the "sessionDataUpdated" event when the data in the browser storage has changed', async function (assert) {
       let triggered = false;
       store.on('sessionDataUpdated', () => {
         triggered = true;
       });
 
       window.dispatchEvent(new StorageEvent('storage', { key: store.get('key') }));
+      await settled();
 
       assert.ok(triggered);
     });
 
-    test('does not trigger the "sessionDataUpdated" event when the data in the browser storage has not changed', function (assert) {
+    test('does not trigger the "sessionDataUpdated" event when the data in the browser storage has not changed', async function (assert) {
       let triggered = false;
       store.on('sessionDataUpdated', () => {
         triggered = true;
@@ -52,17 +54,19 @@ export default function (options) {
 
       store.persist({ key: 'value' }); // this data will be read again when the event is handled so that no change will be detected
       window.dispatchEvent(new StorageEvent('storage', { key: store.get('key') }));
+      await settled();
 
       assert.notOk(triggered);
     });
 
-    test('does not trigger the "sessionDataUpdated" event when the data in the browser storage has changed for a different key', function (assert) {
+    test('does not trigger the "sessionDataUpdated" event when the data in the browser storage has changed for a different key', async function (assert) {
       let triggered = false;
       store.on('sessionDataUpdated', () => {
         triggered = true;
       });
 
       window.dispatchEvent(new StorageEvent('storage', { key: 'another key' }));
+      await settled();
 
       assert.notOk(triggered);
     });


### PR DESCRIPTION
- Removes `rsvp` from the internals and authenticators.
This is a breaking change for users that relied on RSVP behavior, usually when they implement a custom authenticator.

https://rfcs.emberjs.com/id/0796-ember-data-deprecate-rsvp/