### PR TITLE
Remove Evented mixin. Use native EventTarget. 

### DIFF
--- a/packages/ember-simple-auth/src/authenticators/base.js
+++ b/packages/ember-simple-auth/src/authenticators/base.js
@@ -1,5 +1,6 @@
-import Evented from '@ember/object/evented';
 import EmberObject from '@ember/object';
+
+export class AuthenticatorEventTarget extends EventTarget {}
 
 /**
   The base class for all authenticators. __This serves as a starting point for
@@ -51,10 +52,11 @@ import EmberObject from '@ember/object';
 
   @class BaseAuthenticator
   @extends Ember.Object
-  @uses Ember.Evented
   @public
 */
-export default EmberObject.extend(Evented, {
+export default class EsaBaseAuthenticator extends EmberObject {
+  authenticatorEvents = new AuthenticatorEventTarget();
+
   /**
     __Triggered when the authentication data is updated by the authenticator
     due to an external or scheduled event__. This might happen, e.g., if the
@@ -109,7 +111,7 @@ export default EmberObject.extend(Evented, {
   */
   restore() {
     return Promise.reject();
-  },
+  }
 
   /**
     Authenticates the session with the specified `args`. These options vary
@@ -138,7 +140,7 @@ export default EmberObject.extend(Evented, {
   */
   authenticate() {
     return Promise.reject();
-  },
+  }
 
   /**
     This method is invoked as a callback when the session is invalidated. While
@@ -163,5 +165,24 @@ export default EmberObject.extend(Evented, {
   */
   invalidate() {
     return Promise.resolve();
-  },
-});
+  }
+
+  on(event, cb) {
+    this.authenticatorEvents.addEventListener(event, cb);
+  }
+
+  off(event, cb) {
+    this.authenticatorEvents.removeEventListener(event, cb);
+  }
+
+  trigger(event, value) {
+    let customEvent;
+    if (value) {
+      customEvent = new CustomEvent(event, { detail: value });
+    } else {
+      customEvent = new CustomEvent(event);
+    }
+
+    this.authenticatorEvents.dispatchEvent(customEvent);
+  }
+}

--- a/packages/ember-simple-auth/src/authenticators/base.js
+++ b/packages/ember-simple-auth/src/authenticators/base.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 
-export class AuthenticatorEventTarget extends EventTarget {}
+class AuthenticatorEventTarget extends EventTarget {}
 
 /**
   The base class for all authenticators. __This serves as a starting point for

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -227,7 +227,7 @@ export default ObjectProxy.extend(Evented, {
   },
 
   _bindToStoreEvents() {
-    this.store.on('sessionDataUpdated', content => {
+    this.store.on('sessionDataUpdated', ({ detail: content }) => {
       if (!this._busy) {
         this._busy = true;
         let { authenticator: authenticatorFactory } = content.authenticated || {};

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -94,7 +94,7 @@ export default ObjectProxy.extend(Evented, {
     let authenticator = this._lookupAuthenticator(this.authenticator);
     return authenticator.invalidate(this.content.authenticated, ...arguments).then(
       () => {
-        authenticator.off('sessionDataUpdated', this, this._onSessionDataUpdated);
+        authenticator.off('sessionDataUpdated', this._onSessionDataUpdated.bind(this));
         this._busy = false;
         return this._clear(true);
       },
@@ -214,11 +214,11 @@ export default ObjectProxy.extend(Evented, {
 
   _bindToAuthenticatorEvents() {
     const authenticator = this._lookupAuthenticator(this.authenticator);
-    authenticator.on('sessionDataUpdated', this, this._onSessionDataUpdated);
-    authenticator.on('sessionDataInvalidated', this, this._onSessionDataInvalidated);
+    authenticator.on('sessionDataUpdated', this._onSessionDataUpdated.bind(this));
+    authenticator.on('sessionDataInvalidated', this._onSessionDataInvalidated.bind(this));
   },
 
-  _onSessionDataUpdated(content) {
+  _onSessionDataUpdated({ detail: content }) {
     this._setup(this.authenticator, content);
   },
 

--- a/packages/ember-simple-auth/src/session-stores/adaptive.js
+++ b/packages/ember-simple-auth/src/session-stores/adaptive.js
@@ -191,7 +191,7 @@ export default Base.extend({
   },
 
   _setupStoreEvents(store) {
-    store.on('sessionDataUpdated', data => {
+    store.on('sessionDataUpdated', ({ detail: data }) => {
       this.trigger('sessionDataUpdated', data);
     });
     return store;

--- a/packages/ember-simple-auth/src/session-stores/base.js
+++ b/packages/ember-simple-auth/src/session-stores/base.js
@@ -1,5 +1,6 @@
 import EmberObject from '@ember/object';
-import Evented from '@ember/object/evented';
+
+class SessionStoreEventTarget extends EventTarget {}
 
 /**
   The base class for all session stores. __This serves as a starting point for
@@ -10,10 +11,10 @@ import Evented from '@ember/object/evented';
 
   @class BaseStore
   @extends Ember.Object
-  @uses Ember.Evented
   @public
 */
-export default EmberObject.extend(Evented, {
+export default class EsaBaseSessionStore extends EmberObject {
+  sessionStoreEvents = new SessionStoreEventTarget();
   /**
     Triggered when the session store's data changes due to an external event,
     e.g., from another tab or window of the same application. The session
@@ -41,7 +42,7 @@ export default EmberObject.extend(Evented, {
   */
   persist() {
     return Promise.reject();
-  },
+  }
 
   /**
     Returns all data currently stored as a plain object.
@@ -56,7 +57,7 @@ export default EmberObject.extend(Evented, {
   */
   restore() {
     return Promise.reject();
-  },
+  }
 
   /**
     Clears the store.
@@ -71,5 +72,24 @@ export default EmberObject.extend(Evented, {
   */
   clear() {
     return Promise.reject();
-  },
-});
+  }
+
+  on(event, cb) {
+    this.sessionStoreEvents.addEventListener(event, cb);
+  }
+
+  off(event, cb) {
+    this.sessionStoreEvents.removeEventListener(event, cb);
+  }
+
+  trigger(event, value) {
+    let customEvent;
+    if (value) {
+      customEvent = new CustomEvent(event, { detail: value });
+    } else {
+      customEvent = new CustomEvent(event);
+    }
+
+    this.sessionStoreEvents.dispatchEvent(customEvent);
+  }
+}

--- a/packages/test-esa/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/packages/test-esa/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -491,7 +491,7 @@ module('OAuth2PasswordGrantAuthenticator', function (hooks) {
       test('triggers the "sessionDataUpdated" event', async function (assert) {
         assert.expect(2);
         await new Promise(resolve => {
-          authenticator.one('sessionDataUpdated', data => {
+          authenticator.on('sessionDataUpdated', ({ detail: data }) => {
             assert.true(data['expires_at'] > new Date().getTime());
             delete data['expires_at'];
             assert.deepEqual(data, {
@@ -519,7 +519,7 @@ module('OAuth2PasswordGrantAuthenticator', function (hooks) {
         test('triggers the "sessionDataUpdated" event with the correct data', async function (assert) {
           assert.expect(2);
           await new Promise(resolve => {
-            authenticator.one('sessionDataUpdated', data => {
+            authenticator.on('sessionDataUpdated', ({ detail: data }) => {
               assert.true(data['expires_at'] > new Date().getTime());
               delete data['expires_at'];
               assert.deepEqual(data, {
@@ -567,7 +567,7 @@ module('OAuth2PasswordGrantAuthenticator', function (hooks) {
           ]);
 
           await new Promise(resolve => {
-            authenticator.one('sessionDataUpdated', data => {
+            authenticator.on('sessionDataUpdated', ({ detail: data }) => {
               assert.equal(data.scope, 'scope!');
 
               resolve();

--- a/packages/test-esa/tests/unit/internal-session-test.js
+++ b/packages/test-esa/tests/unit/internal-session-test.js
@@ -105,7 +105,7 @@ module('InternalSession', function (hooks) {
       test('triggers the "invalidationSucceeded" event', async function (assert) {
         assert.expect(1);
         let triggered = false;
-        session.one('invalidationSucceeded', () => {
+        session.on('invalidationSucceeded', () => {
           triggered = true;
         });
         authenticator.trigger('sessionDataInvalidated');
@@ -217,7 +217,7 @@ module('InternalSession', function (hooks) {
 
         test('does not trigger the "authenticationSucceeded" event', async function (assert) {
           let triggered = false;
-          session.one('authenticationSucceeded', () => (triggered = true));
+          session.on('authenticationSucceeded', () => (triggered = true));
           await session.restore();
 
           assert.notOk(triggered);
@@ -329,7 +329,7 @@ module('InternalSession', function (hooks) {
 
       test('triggers the "authenticationSucceeded" event', async function (assert) {
         let triggered = false;
-        session.one('authenticationSucceeded', () => (triggered = true));
+        session.on('authenticationSucceeded', () => (triggered = true));
 
         await session.authenticate('authenticator:test');
 
@@ -395,7 +395,7 @@ module('InternalSession', function (hooks) {
         assert.expect(1);
         let triggered = false;
         sinon.stub(authenticator, 'authenticate').rejects('error auth');
-        session.one('authenticationSucceeded', () => (triggered = true));
+        session.on('authenticationSucceeded', () => (triggered = true));
 
         try {
           await session.authenticate('authenticator:test');
@@ -486,7 +486,7 @@ module('InternalSession', function (hooks) {
 
       test('triggers the "invalidationSucceeded" event', async function (assert) {
         let triggered = false;
-        session.one('invalidationSucceeded', () => (triggered = true));
+        session.on('invalidationSucceeded', () => (triggered = true));
 
         await session.invalidate();
 
@@ -551,7 +551,7 @@ module('InternalSession', function (hooks) {
         assert.expect(1);
         sinon.stub(authenticator, 'invalidate').rejects('error');
         let triggered = false;
-        session.one('invalidationSucceeded', () => (triggered = true));
+        session.on('invalidationSucceeded', () => (triggered = true));
 
         try {
           await session.invalidate();
@@ -723,7 +723,7 @@ module('InternalSession', function (hooks) {
             test('does not trigger the "authenticationSucceeded" event', async function (assert) {
               assert.expect(1);
               let triggered = false;
-              session.one('authenticationSucceeded', () => (triggered = true));
+              session.on('authenticationSucceeded', () => (triggered = true));
               store.trigger('sessionDataUpdated', {
                 some: 'other property',
                 authenticated: { authenticator: 'authenticator:test' },
@@ -746,7 +746,7 @@ module('InternalSession', function (hooks) {
             test('triggers the "authenticationSucceeded" event', async function (assert) {
               assert.expect(1);
               let triggered = false;
-              session.one('authenticationSucceeded', () => (triggered = true));
+              session.on('authenticationSucceeded', () => (triggered = true));
               store.trigger('sessionDataUpdated', {
                 some: 'other property',
                 authenticated: { authenticator: 'authenticator:test' },
@@ -828,7 +828,7 @@ module('InternalSession', function (hooks) {
             test('triggers the "invalidationSucceeded" event', async function (assert) {
               assert.expect(1);
               let triggered = false;
-              session.one('invalidationSucceeded', () => (triggered = true));
+              session.on('invalidationSucceeded', () => (triggered = true));
               store.trigger('sessionDataUpdated', {
                 some: 'other property',
                 authenticated: { authenticator: 'authenticator:test' },
@@ -851,7 +851,7 @@ module('InternalSession', function (hooks) {
             test('does not trigger the "invalidationSucceeded" event', async function (assert) {
               assert.expect(1);
               let triggered = false;
-              session.one('invalidationSucceeded', () => (triggered = true));
+              session.on('invalidationSucceeded', () => (triggered = true));
               store.trigger('sessionDataUpdated', {
                 some: 'other property',
                 authenticated: { authenticator: 'authenticator:test' },
@@ -921,7 +921,7 @@ module('InternalSession', function (hooks) {
           test('triggers the "invalidationSucceeded" event', async function (assert) {
             assert.expect(1);
             let triggered = false;
-            session.one('invalidationSucceeded', () => (triggered = true));
+            session.on('invalidationSucceeded', () => (triggered = true));
             store.trigger('sessionDataUpdated', { some: 'other property' });
 
             await new Promise(resolve => {
@@ -941,7 +941,7 @@ module('InternalSession', function (hooks) {
           test('does not trigger the "invalidationSucceeded" event', async function (assert) {
             assert.expect(1);
             let triggered = false;
-            session.one('invalidationSucceeded', () => (triggered = true));
+            session.on('invalidationSucceeded', () => (triggered = true));
             store.trigger('sessionDataUpdated', { some: 'other property' });
 
             await new Promise(resolve => {
@@ -954,7 +954,7 @@ module('InternalSession', function (hooks) {
 
           test('it does not trigger the "sessionInvalidationFailed" event', async function (assert) {
             let triggered = false;
-            session.one('sessionInvalidationFailed', () => (triggered = true));
+            session.on('sessionInvalidationFailed', () => (triggered = true));
 
             await session.invalidate();
 

--- a/packages/test-esa/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/packages/test-esa/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -210,7 +210,7 @@ export default function (options) {
           cookieName: 'ember_simple_auth-session',
         });
         triggered = false;
-        store.one('sessionDataUpdated', () => {
+        store.on('sessionDataUpdated', () => {
           triggered = true;
         });
       });

--- a/packages/test-esa/tests/unit/session-stores/shared/store-behavior.js
+++ b/packages/test-esa/tests/unit/session-stores/shared/store-behavior.js
@@ -42,7 +42,7 @@ export default function (options) {
     test('does not trigger the "sessionDataUpdated" event', async function (assert) {
       assert.expect(1);
       let triggered = false;
-      store.one('sessionDataUpdated', () => (triggered = true));
+      store.on('sessionDataUpdated', () => (triggered = true));
       store.persist({ key: 'other value' });
       syncExternalChanges(store);
 


### PR DESCRIPTION
- Removes Evented Mixin
This is a prerequisite to making everything ES6 classes and make it easier to convert to Typescript.

Mostly keeps the API the same except for the fact that we extend the Native `EventTarget` and emit `CustomEvent`s which require to provide data as a `detail` field.

Event handlers must change from
```js
  authenticator.on('sessionDataUpdated', data => {
```

to

```js
 authenticator.on('sessionDataUpdated', ({ detail: data }) => {
```

Additionally, not the whole Evented API is implemented on the `Authenticator`, `Store` and `InternalSession` objects.
Only `on`, `off` and `trigger` methods are supported.

Currently I'm not convinced that the events are needed but also don't see a need  to refactor away.

Lastly, I've discovered a different behavior of the `internal-session.js` once the `ObjectProxy` was refactored to ES6 such as `export default class InternalSession extends ObjectProxy {}` as opposed to the current classic syntax `export default ObjectProxy.extend({})`, for some reason `set`,`get` and `setProperties`  calls proxying misbehave when the methods are implemented outside the `extend({})` body.
