### PR TITLE
refactor(ember-simple-auth): authenticators to use ES6 classes

### DIFF
--- a/packages/ember-simple-auth/src/authenticators/devise.js
+++ b/packages/ember-simple-auth/src/authenticators/devise.js
@@ -17,7 +17,7 @@ const JSON_CONTENT_TYPE = 'application/json';
   @extends BaseAuthenticator
   @public
 */
-export default BaseAuthenticator.extend({
+export default class DeviseAuthenticator extends BaseAuthenticator {
   /**
     The endpoint on the server that the authentication request is sent to.
 
@@ -27,7 +27,7 @@ export default BaseAuthenticator.extend({
     @default '/users/sign_in'
     @public
   */
-  serverTokenEndpoint: '/users/sign_in',
+  serverTokenEndpoint = '/users/sign_in';
 
   /**
     The devise resource name. __This will be used in the request and also be
@@ -39,7 +39,7 @@ export default BaseAuthenticator.extend({
     @default 'user'
     @public
   */
-  resourceName: 'user',
+  resourceName = 'user';
 
   /**
     The token attribute name. __This will be used in the request and also be
@@ -51,7 +51,7 @@ export default BaseAuthenticator.extend({
     @default 'token'
     @public
   */
-  tokenAttributeName: 'token',
+  tokenAttributeName = 'token';
 
   /**
     The identification attribute name. __This will be used in the request and
@@ -63,7 +63,7 @@ export default BaseAuthenticator.extend({
     @default 'email'
     @public
   */
-  identificationAttributeName: 'email',
+  identificationAttributeName = 'email';
 
   /**
     Restores the session from a session data object; __returns a resolving
@@ -80,9 +80,8 @@ export default BaseAuthenticator.extend({
     @public
   */
   restore(data) {
-    // eslint-disable-next-line prefer-promise-reject-errors
     return this._validate(data) ? Promise.resolve(data) : Promise.reject();
-  },
+  }
 
   /**
     Authenticates the session with the specified `identification` and
@@ -136,7 +135,7 @@ export default BaseAuthenticator.extend({
         })
         .catch(error => run(null, reject, error));
     });
-  },
+  }
 
   /**
     Does nothing
@@ -148,7 +147,7 @@ export default BaseAuthenticator.extend({
   */
   invalidate() {
     return Promise.resolve();
-  },
+  }
 
   /**
     Makes a request to the Devise server using
@@ -161,7 +160,8 @@ export default BaseAuthenticator.extend({
     @return {Promise} The promise returned by `fetch`
     @protected
   */
-  makeRequest: waitFor(function (data, options = {}) {
+  @waitFor
+  makeRequest(data, options = {}) {
     let url = options.url || this.get('serverTokenEndpoint');
     let requestOptions = {};
     let body = JSON.stringify(data);
@@ -176,7 +176,7 @@ export default BaseAuthenticator.extend({
     Object.assign(requestOptions, options || {});
 
     return fetch(url, requestOptions);
-  }),
+  }
 
   _validate(data) {
     const tokenAttributeName = this.get('tokenAttributeName');
@@ -185,5 +185,5 @@ export default BaseAuthenticator.extend({
     const _data = data[resourceName] ? data[resourceName] : data;
 
     return !isEmpty(_data[tokenAttributeName]) && !isEmpty(_data[identificationAttributeName]);
-  },
-});
+  }
+}

--- a/packages/ember-simple-auth/src/authenticators/oauth2-implicit-grant.js
+++ b/packages/ember-simple-auth/src/authenticators/oauth2-implicit-grant.js
@@ -42,7 +42,7 @@ export function parseResponse(locationHash) {
  @extends BaseAuthenticator
  @public
  */
-export default BaseAuthenticator.extend({
+export default class OAuth2ImplicitGrantAuthenticator extends BaseAuthenticator {
   /**
    Restores the session from a session data object; __will return a resolving
    promise when there is a non-empty `access_token` in the session data__ and
@@ -62,7 +62,7 @@ export default BaseAuthenticator.extend({
 
       return resolve(data);
     });
-  },
+  }
 
   /**
    Authenticates the session using the specified location `hash`
@@ -89,7 +89,7 @@ export default BaseAuthenticator.extend({
         resolve(hash);
       }
     });
-  },
+  }
 
   /**
    This method simply returns a resolving promise.
@@ -101,11 +101,11 @@ export default BaseAuthenticator.extend({
    */
   invalidate() {
     return Promise.resolve();
-  },
+  }
 
   _validateData(data) {
     // see https://tools.ietf.org/html/rfc6749#section-4.2.2
 
     return !isEmpty(data) && !isEmpty(data.access_token);
-  },
-});
+  }
+}

--- a/packages/ember-simple-auth/src/authenticators/oauth2-password-grant.js
+++ b/packages/ember-simple-auth/src/authenticators/oauth2-password-grant.js
@@ -21,7 +21,7 @@ import { isTesting } from '@embroider/macros';
   @extends BaseAuthenticator
   @public
 */
-export default BaseAuthenticator.extend({
+export default class OAuth2PasswordGrantAuthenticator extends BaseAuthenticator {
   /**
     Triggered when the authenticator refreshed the access token (see
     [RFC 6749, section 6](http://tools.ietf.org/html/rfc6749#section-6)).
@@ -46,7 +46,7 @@ export default BaseAuthenticator.extend({
     @default null
     @public
   */
-  clientId: null,
+  clientId = null;
 
   /**
     The endpoint on the server that authentication and token refresh requests
@@ -58,7 +58,7 @@ export default BaseAuthenticator.extend({
     @default '/token'
     @public
   */
-  serverTokenEndpoint: '/token',
+  serverTokenEndpoint = '/token';
 
   /**
     The endpoint on the server that token revocation requests are sent to. Only
@@ -75,7 +75,7 @@ export default BaseAuthenticator.extend({
     @default null
     @public
   */
-  serverTokenRevocationEndpoint: null,
+  serverTokenRevocationEndpoint = null;
 
   /**
     Sets whether the authenticator automatically refreshes access tokens if the
@@ -87,7 +87,7 @@ export default BaseAuthenticator.extend({
     @default true
     @public
   */
-  refreshAccessTokens: true,
+  refreshAccessTokens = true;
 
   /**
     Sets whether the authenticator use the scope when refreshing access tokens
@@ -99,7 +99,7 @@ export default BaseAuthenticator.extend({
     @default false
     @public
   */
-  refreshAccessTokensWithScope: false,
+  refreshAccessTokensWithScope = false;
 
   /**
     The offset time in milliseconds to refresh the access token. This must
@@ -122,9 +122,9 @@ export default BaseAuthenticator.extend({
     const max = 10;
 
     return (Math.floor(Math.random() * (max - min)) + min) * 1000;
-  },
+  }
 
-  _refreshTokenTimeout: null,
+  _refreshTokenTimeout = null;
 
   /**
     Restores the session from a session data object; __will return a resolving
@@ -170,7 +170,7 @@ export default BaseAuthenticator.extend({
         }
       }
     });
-  },
+  }
 
   /**
     Authenticates the session with the specified `identification`, `password`
@@ -262,7 +262,7 @@ export default BaseAuthenticator.extend({
         }
       );
     });
-  },
+  }
 
   /**
     If token revocation is enabled, this will revoke the access token (and the
@@ -308,7 +308,7 @@ export default BaseAuthenticator.extend({
         Promise.all(requests).then(succeed, succeed);
       }
     });
-  },
+  }
 
   /**
     Makes a request to the OAuth 2.0 server.
@@ -321,7 +321,8 @@ export default BaseAuthenticator.extend({
     @return {Promise} A promise that resolves with the response object
     @protected
   */
-  makeRequest: waitFor(function (url, data, headers = {}) {
+  @waitFor
+  makeRequest(url, data, headers = {}) {
     headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
     const clientId = this.get('clientId');
@@ -361,7 +362,7 @@ export default BaseAuthenticator.extend({
         })
         .catch(reject);
     });
-  }),
+  }
 
   _scheduleAccessTokenRefresh(expiresIn, expiresAt, refreshToken) {
     const refreshAccessTokens = this.get('refreshAccessTokens') && !isFastBoot(getOwner(this));
@@ -385,7 +386,7 @@ export default BaseAuthenticator.extend({
         }
       }
     }
-  },
+  }
 
   _refreshAccessToken(expiresIn, refreshToken, scope) {
     const data = { grant_type: 'refresh_token', refresh_token: refreshToken };
@@ -426,15 +427,15 @@ export default BaseAuthenticator.extend({
         }
       );
     });
-  },
+  }
 
   _absolutizeExpirationTime(expiresIn) {
     if (!isEmpty(expiresIn)) {
       return new Date(new Date().getTime() + expiresIn * 1000).getTime();
     }
-  },
+  }
 
   _validate(data) {
     return !isEmpty(data['access_token']);
-  },
-});
+  }
+}

--- a/packages/ember-simple-auth/src/authenticators/test.js
+++ b/packages/ember-simple-auth/src/authenticators/test.js
@@ -1,15 +1,15 @@
 import BaseAuthenticator from './base';
 
-export default BaseAuthenticator.extend({
+export default class TestAuthenticator extends BaseAuthenticator {
   restore(data) {
     return Promise.resolve(data);
-  },
+  }
 
   authenticate(data) {
     return Promise.resolve(data);
-  },
+  }
 
   invalidate() {
     return Promise.resolve();
-  },
-});
+  }
+}

--- a/packages/ember-simple-auth/src/authenticators/torii.js
+++ b/packages/ember-simple-auth/src/authenticators/torii.js
@@ -35,8 +35,8 @@ deprecate('Ember Simple Auth: The Torii authenticator is deprecated.', false, {
   @extends BaseAuthenticator
   @public
 */
-export default BaseAuthenticator.extend({
-  _provider: null,
+export default class ToriiAuthenticator extends BaseAuthenticator {
+  _provider = null;
 
   /**
     Restores the session by calling the torii provider's `fetch` method.
@@ -84,7 +84,7 @@ export default BaseAuthenticator.extend({
       delete this._provider;
       return Promise.reject();
     }
-  },
+  }
 
   /**
     Authenticates the session by opening the specified torii provider. For more
@@ -109,7 +109,7 @@ export default BaseAuthenticator.extend({
         this._authenticateWithProvider(provider, data);
         return data;
       });
-  },
+  }
 
   /**
     Closes the torii provider. If the provider is successfully closed, this
@@ -127,12 +127,12 @@ export default BaseAuthenticator.extend({
       .then(() => {
         delete this._provider;
       });
-  },
+  }
 
   _authenticateWithProvider(provider, data) {
     data.provider = provider;
     this._provider = data.provider;
-  },
+  }
 
   _assertToriiIsPresent() {
     const torii = this.get('torii');
@@ -140,5 +140,5 @@ export default BaseAuthenticator.extend({
       'You are trying to use the torii authenticator but torii is not available. Inject torii into the authenticator with "torii: Ember.inject.service()".',
       isPresent(torii)
     );
-  },
-});
+  }
+}

--- a/packages/test-esa/tests/unit/authenticators/devise-test.js
+++ b/packages/test-esa/tests/unit/authenticators/devise-test.js
@@ -8,7 +8,7 @@ module('DeviseAuthenticator', function (hooks) {
 
   hooks.beforeEach(function () {
     server = new Pretender();
-    authenticator = Devise.create();
+    authenticator = new Devise();
   });
 
   hooks.afterEach(function () {
@@ -31,11 +31,12 @@ module('DeviseAuthenticator', function (hooks) {
 
     module('when the data contains a custom token and email attribute', function (hooks) {
       hooks.beforeEach(function () {
-        authenticator = Devise.extend({
-          resourceName: 'employee',
-          tokenAttributeName: 'token',
-          identificationAttributeName: 'email',
-        }).create();
+        class TestEmployeeDevise extends Devise {
+          resourceName = 'employee';
+          tokenAttributeName = 'token';
+          identificationAttributeName = 'email';
+        }
+        authenticator = new TestEmployeeDevise();
       });
 
       test('resolves with the correct data', async function (assert) {


### PR DESCRIPTION
- Changes authenticators to use ES6 classes instead of Classic Ember .extend method.
Might require users to also use ES6 syntax if they haven't yet.