### PR TITLE
refactor(ember-simple-auth): session-stores to use ES6 classes

### DIFF
--- a/packages/ember-simple-auth/src/session-stores/cookie.js
+++ b/packages/ember-simple-auth/src/session-stores/cookie.js
@@ -69,9 +69,9 @@ const persistingProperty = function (beforeSet = function () {}) {
   @extends BaseStore
   @public
 */
-export default BaseStore.extend({
-  _syncDataTimeout: null,
-  _renewExpirationTimeout: null,
+export default class CookieStore extends BaseStore {
+  _syncDataTimeout = null;
+  _renewExpirationTimeout = null;
 
   /**
     The domain to use for the cookie, e.g., "example.com", ".example.com"
@@ -85,8 +85,9 @@ export default BaseStore.extend({
     @default null
     @public
   */
-  _cookieDomain: null,
-  cookieDomain: persistingProperty(),
+  _cookieDomain = null;
+  @persistingProperty()
+  cookieDomain;
 
   /**
     Allows servers to assert that a cookie ought not to be sent along with cross-site requests,
@@ -100,8 +101,9 @@ export default BaseStore.extend({
     @default null
     @public
   */
-  _sameSite: null,
-  sameSite: persistingProperty(),
+  _sameSite = null;
+  @persistingProperty()
+  sameSite;
 
   /**
     The name of the cookie.
@@ -112,10 +114,11 @@ export default BaseStore.extend({
     @default ember_simple_auth-session
     @public
   */
-  _cookieName: 'ember_simple_auth-session',
-  cookieName: persistingProperty(function () {
+  _cookieName = 'ember_simple_auth-session';
+  @persistingProperty(function () {
     this._oldCookieName = this._cookieName;
-  }),
+  })
+  cookieName;
 
   /**
     The path to use for the cookie, e.g., "/", "/something".
@@ -126,8 +129,9 @@ export default BaseStore.extend({
     @default '/'
     @public
   */
-  _cookiePath: '/',
-  cookiePath: persistingProperty(),
+  _cookiePath = '/';
+  @persistingProperty()
+  cookiePath;
 
   /**
     The expiration time for the cookie in seconds. A value of `null` will make
@@ -144,8 +148,8 @@ export default BaseStore.extend({
     @type Integer
     @public
   */
-  _cookieExpirationTime: null,
-  cookieExpirationTime: persistingProperty(function (key, value) {
+  _cookieExpirationTime = null;
+  @persistingProperty(function (key, value) {
     // When nulling expiry time on purpose, we need to clear the cached value.
     // Otherwise, `_calculateExpirationTime` will reuse it.
     if (isNone(value)) {
@@ -157,7 +161,8 @@ export default BaseStore.extend({
         { id: 'ember-simple-auth.cookieExpirationTime' }
       );
     }
-  }),
+  })
+  cookieExpirationTime;
 
   /**
     Allows servers to assert that a cookie should opt in to partitioned storage,
@@ -174,10 +179,11 @@ export default BaseStore.extend({
     @default null
     @public
   */
-  _partitioned: null,
-  partitioned: persistingProperty(),
+  _partitioned = null;
+  @persistingProperty()
+  partitioned;
 
-  _cookies: service('cookies'),
+  @service('cookies') _cookies;
 
   _secureCookies() {
     if (this.get('_fastboot.isFastBoot')) {
@@ -185,7 +191,7 @@ export default BaseStore.extend({
     }
 
     return window.location.protocol === 'https:';
-  },
+  }
 
   _isPageVisible() {
     if (this.get('_fastboot.isFastBoot')) {
@@ -195,7 +201,7 @@ export default BaseStore.extend({
         typeof document !== 'undefined' ? document.visibilityState || 'visible' : false;
       return visibilityState === 'visible';
     }
-  },
+  }
 
   init() {
     this._super(...arguments);
@@ -218,7 +224,7 @@ export default BaseStore.extend({
     } else {
       this._renew();
     }
-  },
+  }
 
   /**
     Persists the `data` in the cookie.
@@ -235,7 +241,7 @@ export default BaseStore.extend({
     let expiration = this._calculateExpirationTime();
     this._write(data, expiration);
     return Promise.resolve();
-  },
+  }
 
   /**
     Returns all data currently stored in the cookie as a plain object.
@@ -252,7 +258,7 @@ export default BaseStore.extend({
     } else {
       return Promise.resolve(JSON.parse(data));
     }
-  },
+  }
 
   /**
     Clears the store by deleting the cookie.
@@ -266,11 +272,11 @@ export default BaseStore.extend({
     this._write('', 0);
     this._lastData = {};
     return Promise.resolve();
-  },
+  }
 
   _read(name) {
     return this.get('_cookies').read(name) || '';
-  },
+  }
 
   _calculateExpirationTime() {
     let cachedExpirationTime = this._read(`${this.get('cookieName')}-expiration_time`);
@@ -280,7 +286,7 @@ export default BaseStore.extend({
     return this.get('cookieExpirationTime')
       ? new Date().getTime() + this.get('cookieExpirationTime') * 1000
       : cachedExpirationTime;
-  },
+  }
 
   _write(value, expiration) {
     let cookieOptions = {
@@ -307,7 +313,7 @@ export default BaseStore.extend({
         cookieOptions
       );
     }
-  },
+  }
 
   _syncData() {
     return this.restore().then(data => {
@@ -320,7 +326,7 @@ export default BaseStore.extend({
         this._syncDataTimeout = later(this, this._syncData, 500);
       }
     });
-  },
+  }
 
   _renew() {
     return this.restore().then(data => {
@@ -330,7 +336,7 @@ export default BaseStore.extend({
         this._write(data, expiration);
       }
     });
-  },
+  }
 
   _renewExpiration() {
     if (!isTesting()) {
@@ -342,7 +348,7 @@ export default BaseStore.extend({
     } else {
       return Promise.resolve();
     }
-  },
+  }
 
   rewriteCookie() {
     // if `cookieName` has not been renamed, `oldCookieName` will be nil
@@ -352,5 +358,5 @@ export default BaseStore.extend({
       const expiration = this._calculateExpirationTime();
       this._write(data, expiration);
     }
-  },
-});
+  }
+}

--- a/packages/test-esa/tests/unit/session-stores/adaptive-test.js
+++ b/packages/test-esa/tests/unit/session-stores/adaptive-test.js
@@ -59,7 +59,7 @@ module('AdaptiveStore', function (hooks) {
     module('Behaviour', function (hooks) {
       itBehavesLikeACookieStore({
         hooks,
-        store(sinon, owner, storeOptions) {
+        store(sinon, owner, { adaptive: storeOptions } = {}) {
           owner.register('service:cookies', FakeCookieService);
           let cookieService = owner.lookup('service:cookies');
           sinon.spy(cookieService, 'read');

--- a/packages/test-esa/tests/unit/session-stores/cookie-test.js
+++ b/packages/test-esa/tests/unit/session-stores/cookie-test.js
@@ -5,6 +5,14 @@ import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
 import CookieStore from 'ember-simple-auth/session-stores/cookie';
 
+class TestStoreBehavior extends CookieStore {
+  _cookieName = 'test-session';
+}
+
+class TestCookieStoreBehavior extends CookieStore {
+  _cookieName = 'test:session';
+}
+
 module('CookieStore', function (hooks) {
   setupTest(hooks);
 
@@ -18,12 +26,7 @@ module('CookieStore', function (hooks) {
         cookieService = owner.lookup('service:cookies');
         sinon.spy(cookieService, 'read');
         sinon.spy(cookieService, 'write');
-        owner.register(
-          'session-store:cookie',
-          CookieStore.extend({
-            _cookieName: 'test-session',
-          })
-        );
+        owner.register('session-store:cookie', TestStoreBehavior);
         store = owner.lookup('session-store:cookie');
         return store;
       },
@@ -36,22 +39,12 @@ module('CookieStore', function (hooks) {
   module('CookieStoreBehavior', function (hooks) {
     itBehavesLikeACookieStore({
       hooks,
-      store(sinon, owner, storeOptions) {
+      store(sinon, owner, { cookie: klass } = {}) {
         owner.register('service:cookies', FakeCookieService);
         let cookieService = owner.lookup('service:cookies');
         sinon.spy(cookieService, 'read');
         sinon.spy(cookieService, 'write');
-        owner.register(
-          'session-store:cookie',
-          CookieStore.extend(
-            Object.assign(
-              {
-                _cookieName: 'test:session',
-              },
-              storeOptions
-            )
-          )
-        );
+        owner.register('session-store:cookie', klass || TestCookieStoreBehavior);
         let store = owner.lookup('session-store:cookie');
         return store;
       },

--- a/packages/test-esa/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/packages/test-esa/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -3,6 +3,7 @@ import { next, run } from '@ember/runloop';
 import { registerWarnHandler } from '@ember/debug';
 import sinonjs from 'sinon';
 import FakeCookieService from '../../../helpers/fake-cookie-service';
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
 
 let warnings;
 registerWarnHandler((message, options, next) => {
@@ -173,8 +174,14 @@ export default function (options) {
     hooks.beforeEach(async function () {
       run(() => {
         store = options.store(sinon, this.owner, {
-          cookieName: 'test-session',
-          cookieExpirationTime: 60,
+          cookie: class TestRenewCookieStore extends CookieStore {
+            cookieName = 'test-session';
+            cookieExpirationTime = 60;
+          },
+          adaptive: {
+            cookieName: 'test-session',
+            cookieExpirationTime: 60,
+          },
         });
         cookieService = store.get('_cookies');
       });
@@ -207,7 +214,12 @@ export default function (options) {
     hooks.beforeEach(async function () {
       run(() => {
         store = options.store(sinon, this.owner, {
-          cookieName: 'ember_simple_auth-session',
+          cookie: class TestRenewCookieStore extends CookieStore {
+            cookieName = 'ember_simple_auth-session';
+          },
+          adaptive: {
+            cookieName: 'ember_simple_auth-session',
+          },
         });
         triggered = false;
         store.on('sessionDataUpdated', () => {
@@ -271,8 +283,14 @@ export default function (options) {
       run(() => {
         cookieService = FakeCookieService.create();
         store = options.store(sinon, this.owner, {
-          _cookieName: 'session-foo',
-          _cookieExpirationTime: 1000,
+          cookie: class TestRenewCookieStore extends CookieStore {
+            _cookieName = 'session-foo';
+            _cookieExpirationTime = 1000;
+          },
+          adaptive: {
+            _cookieName: 'session-foo',
+            _cookieExpirationTime: 1000,
+          },
         });
         cookieService = store.get('_cookies') || store.get('_store._cookies');
         cookieSpy = spyRewriteCookieMethod(sinon, store);
@@ -423,7 +441,12 @@ export default function (options) {
     hooks.beforeEach(async function () {
       run(() => {
         store = options.store(sinon, this.owner, {
-          cookieExpirationTime: expirationTime,
+          cookie: class TestRenewCookieStore extends CookieStore {
+            cookieExpirationTime = expirationTime;
+          },
+          adaptive: {
+            cookieExpirationTime: expirationTime,
+          },
         });
         cookieService = store.get('_cookies');
       });


### PR DESCRIPTION
- Refactors cookie session-store to use ES6 class syntax.
- Changes how the test suite is configured for Adaptive and Cookie store testing.
We now provide both configurations within the cookie behaviour "testing macro" for `adaptive` and `cookie` stores, since a single object can't configure both classes anymore.