### PR TITLE
refactor(typescript): migrate session-stores to typescript

### DIFF
--- a/packages/ember-simple-auth/babel.config.json
+++ b/packages/ember-simple-auth/babel.config.json
@@ -2,7 +2,7 @@
   "plugins": [
     [
       "@babel/plugin-transform-typescript",
-      { "allExtensions": true, "onlyRemoveTypeImports": true }
+      { "allExtensions": true, "onlyRemoveTypeImports": true, "allowDeclareFields": true }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "legacy": true }],

--- a/packages/ember-simple-auth/src/authenticators/base.ts
+++ b/packages/ember-simple-auth/src/authenticators/base.ts
@@ -115,7 +115,7 @@ export default class EsaBaseAuthenticator extends EmberObject {
     @member
     @public
   */
-  restore(...args: any[]): Promise<unknown> {
+  restore(..._args: any[]): Promise<unknown> {
     return Promise.reject();
   }
 
@@ -144,7 +144,7 @@ export default class EsaBaseAuthenticator extends EmberObject {
     @member
     @public
   */
-  authenticate(...args: any[]): Promise<unknown> {
+  authenticate(..._args: any[]): Promise<unknown> {
     return Promise.reject();
   }
 
@@ -169,7 +169,7 @@ export default class EsaBaseAuthenticator extends EmberObject {
     @member
     @public
   */
-  invalidate(...args: any[]): Promise<unknown> {
+  invalidate(..._args: any[]): Promise<unknown> {
     return Promise.resolve();
   }
 

--- a/packages/ember-simple-auth/src/session-stores/application.js
+++ b/packages/ember-simple-auth/src/session-stores/application.js
@@ -1,3 +1,0 @@
-import Adaptive from './adaptive';
-
-export default Adaptive;

--- a/packages/ember-simple-auth/src/session-stores/application.ts
+++ b/packages/ember-simple-auth/src/session-stores/application.ts
@@ -1,0 +1,1 @@
+export { default } from './adaptive';

--- a/packages/ember-simple-auth/src/session-stores/base.ts
+++ b/packages/ember-simple-auth/src/session-stores/base.ts
@@ -1,6 +1,11 @@
 import EmberObject from '@ember/object';
+import { TypedEventTarget, type TypedEventListener } from 'typescript-event-target';
 
-class SessionStoreEventTarget extends EventTarget {}
+export interface SessionEvents {
+  sessionDataUpdated: CustomEvent<any>;
+}
+
+class SessionStoreEventTarget extends TypedEventTarget<SessionEvents> {}
 
 /**
   The base class for all session stores. __This serves as a starting point for
@@ -40,7 +45,7 @@ export default class EsaBaseSessionStore extends EmberObject {
     @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
-  persist() {
+  persist(..._args: any[]): Promise<unknown> {
     return Promise.reject();
   }
 
@@ -55,7 +60,7 @@ export default class EsaBaseSessionStore extends EmberObject {
     @return {Promise} A promise that resolves with the data currently persisted in the store when the data has been restored successfully and rejects otherwise.
     @public
   */
-  restore() {
+  restore(..._args: any[]): Promise<unknown> {
     return Promise.reject();
   }
 
@@ -70,19 +75,25 @@ export default class EsaBaseSessionStore extends EmberObject {
     @return {Promise} A promise that resolves when the store has been cleared successfully and rejects otherwise.
     @public
   */
-  clear() {
+  clear(..._args: any[]): Promise<unknown> {
     return Promise.reject();
   }
 
-  on(event, cb) {
+  on<Event extends keyof SessionEvents>(
+    event: Event,
+    cb: TypedEventListener<SessionEvents, Event>
+  ) {
     this.sessionStoreEvents.addEventListener(event, cb);
   }
 
-  off(event, cb) {
+  off<Event extends keyof SessionEvents>(
+    event: Event,
+    cb: TypedEventListener<SessionEvents, Event>
+  ) {
     this.sessionStoreEvents.removeEventListener(event, cb);
   }
 
-  trigger(event, value) {
+  trigger<Event extends keyof SessionEvents>(event: Event, value: SessionEvents[Event]['detail']) {
     let customEvent;
     if (value) {
       customEvent = new CustomEvent(event, { detail: value });
@@ -90,6 +101,6 @@ export default class EsaBaseSessionStore extends EmberObject {
       customEvent = new CustomEvent(event);
     }
 
-    this.sessionStoreEvents.dispatchEvent(customEvent);
+    this.sessionStoreEvents.dispatchTypedEvent(event, customEvent);
   }
 }

--- a/packages/ember-simple-auth/src/session-stores/cookie.ts
+++ b/packages/ember-simple-auth/src/session-stores/cookie.ts
@@ -1,15 +1,16 @@
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { later, cancel, scheduleOnce, next } from '@ember/runloop';
-import { isPresent, typeOf, isEmpty, isNone } from '@ember/utils';
+import { later, cancel, scheduleOnce, next, type Timer } from '@ember/runloop';
+import { typeOf, isEmpty, isNone } from '@ember/utils';
 import { A } from '@ember/array';
-import { getOwner } from '@ember/application';
 import { warn } from '@ember/debug';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
 import { isTesting } from '@embroider/macros';
+import type CookiesService from 'ember-cookies/services/cookies';
+import type { WriteOptions } from 'ember-cookies/services/cookies';
 
-const persistingProperty = function (beforeSet = function () {}) {
+const persistingProperty = function (beforeSet = function (_key: string, _value: any) {}) {
   return computed({
     get(key) {
       return this.get(`_${key}`);
@@ -70,9 +71,8 @@ const persistingProperty = function (beforeSet = function () {}) {
   @public
 */
 export default class CookieStore extends BaseStore {
-  _syncDataTimeout = null;
-  _renewExpirationTimeout = null;
-
+  _syncDataTimeout: Timer | null = null;
+  _renewExpirationTimeout: Timer | null = null;
   /**
     The domain to use for the cookie, e.g., "example.com", ".example.com"
     (which includes all subdomains) or "subdomain.example.com". If not
@@ -87,7 +87,7 @@ export default class CookieStore extends BaseStore {
   */
   _cookieDomain = null;
   @persistingProperty()
-  cookieDomain;
+  cookieDomain = null;
 
   /**
     Allows servers to assert that a cookie ought not to be sent along with cross-site requests,
@@ -103,7 +103,7 @@ export default class CookieStore extends BaseStore {
   */
   _sameSite = null;
   @persistingProperty()
-  sameSite;
+  sameSite = null;
 
   /**
     The name of the cookie.
@@ -115,10 +115,12 @@ export default class CookieStore extends BaseStore {
     @public
   */
   _cookieName = 'ember_simple_auth-session';
-  @persistingProperty(function () {
+
+  _oldCookieName: string | null = null;
+  @persistingProperty(function (this: CookieStore) {
     this._oldCookieName = this._cookieName;
   })
-  cookieName;
+  cookieName = 'ember_simple_auth-session';
 
   /**
     The path to use for the cookie, e.g., "/", "/something".
@@ -131,7 +133,7 @@ export default class CookieStore extends BaseStore {
   */
   _cookiePath = '/';
   @persistingProperty()
-  cookiePath;
+  cookiePath = '/';
 
   /**
     The expiration time for the cookie in seconds. A value of `null` will make
@@ -149,7 +151,7 @@ export default class CookieStore extends BaseStore {
     @public
   */
   _cookieExpirationTime = null;
-  @persistingProperty(function (key, value) {
+  @persistingProperty(function (this: CookieStore, key, value) {
     // When nulling expiry time on purpose, we need to clear the cached value.
     // Otherwise, `_calculateExpirationTime` will reuse it.
     if (isNone(value)) {
@@ -162,7 +164,7 @@ export default class CookieStore extends BaseStore {
       );
     }
   })
-  cookieExpirationTime;
+  cookieExpirationTime = null;
 
   /**
     Allows servers to assert that a cookie should opt in to partitioned storage,
@@ -181,11 +183,13 @@ export default class CookieStore extends BaseStore {
   */
   _partitioned = null;
   @persistingProperty()
-  partitioned;
+  partitioned = null;
 
-  @service('cookies') _cookies;
+  @service('cookies') declare _cookies: CookiesService;
 
-  _secureCookies() {
+  @service('fastboot') declare _fastboot: any;
+
+  _secureCookies(): boolean {
     if (this.get('_fastboot.isFastBoot')) {
       return this.get('_fastboot.request.protocol') === 'https:';
     }
@@ -203,15 +207,14 @@ export default class CookieStore extends BaseStore {
     }
   }
 
-  init() {
-    this._super(...arguments);
-    let owner = getOwner(this);
-    if (owner && !this.hasOwnProperty('_fastboot')) {
-      this._fastboot = owner.lookup('service:fastboot');
-    }
+  _isFastBoot: boolean = false;
+  _lastData: Record<string, string> | null = null;
+
+  constructor(owner: any) {
+    super(owner);
 
     let cachedExpirationTime = this._read(`${this.get('cookieName')}-expiration_time`);
-    if (cachedExpirationTime) {
+    if (typeof cachedExpirationTime === 'string' || typeof cachedExpirationTime === 'number') {
       this.set('cookieExpirationTime', parseInt(cachedExpirationTime, 10));
     }
 
@@ -235,11 +238,11 @@ export default class CookieStore extends BaseStore {
     @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
-  persist(data) {
+  persist(data: Record<string, string>) {
     this._lastData = data;
-    data = JSON.stringify(data || {});
+    const stringifiedData = JSON.stringify(data || {});
     let expiration = this._calculateExpirationTime();
-    this._write(data, expiration);
+    this._write(stringifiedData, expiration);
     return Promise.resolve();
   }
 
@@ -253,11 +256,7 @@ export default class CookieStore extends BaseStore {
   */
   restore() {
     let data = this._read(this.get('cookieName'));
-    if (isEmpty(data)) {
-      return Promise.resolve({});
-    } else {
-      return Promise.resolve(JSON.parse(data));
-    }
+    return Promise.resolve(JSON.parse(typeof data === 'string' ? data : '{}'));
   }
 
   /**
@@ -274,34 +273,40 @@ export default class CookieStore extends BaseStore {
     return Promise.resolve();
   }
 
-  _read(name) {
+  _read(name: string) {
     return this.get('_cookies').read(name) || '';
   }
 
-  _calculateExpirationTime() {
-    let cachedExpirationTime = this._read(`${this.get('cookieName')}-expiration_time`);
-    cachedExpirationTime = cachedExpirationTime
-      ? new Date().getTime() + cachedExpirationTime * 1000
-      : null;
-    return this.get('cookieExpirationTime')
-      ? new Date().getTime() + this.get('cookieExpirationTime') * 1000
-      : cachedExpirationTime;
+  _calculateExpirationTime(): number | undefined {
+    const cachedExpirationTimeCookie = this._read(`${this.get('cookieName')}-expiration_time`);
+
+    const cachedExpirationTime =
+      cachedExpirationTimeCookie && typeof cachedExpirationTimeCookie === 'number'
+        ? new Date().getTime() + cachedExpirationTimeCookie * 1000
+        : null;
+
+    const thisCookieExpirationTime = this.get('cookieExpirationTime');
+
+    return thisCookieExpirationTime
+      ? new Date().getTime() + thisCookieExpirationTime * 1000
+      : cachedExpirationTime || undefined;
   }
 
-  _write(value, expiration) {
-    let cookieOptions = {
-      domain: this.get('cookieDomain'),
-      expires: isEmpty(expiration) ? null : new Date(expiration),
+  _write(value: string, expiration: number | undefined) {
+    let cookieOptions: WriteOptions = {
+      domain: this.get('cookieDomain') || undefined,
+      expires: !expiration ? undefined : new Date(expiration),
       path: this.get('cookiePath'),
       secure: this._secureCookies(),
-      sameSite: this.get('sameSite'),
-      partitioned: this.get('partitioned'),
+      sameSite: this.get('sameSite') || undefined,
+      partitioned: this.partitioned || undefined,
     };
+
     if (this._oldCookieName) {
       A([this._oldCookieName, `${this._oldCookieName}-expiration_time`]).forEach(oldCookie => {
         this.get('_cookies').clear(oldCookie);
       });
-      delete this._oldCookieName;
+      this._oldCookieName = null;
     }
     this.get('_cookies').write(this.get('cookieName'), value, cookieOptions);
     if (!isEmpty(expiration)) {
@@ -322,7 +327,7 @@ export default class CookieStore extends BaseStore {
         this.trigger('sessionDataUpdated', data);
       }
       if (!isTesting()) {
-        cancel(this._syncDataTimeout);
+        this._syncDataTimeout && cancel(this._syncDataTimeout);
         this._syncDataTimeout = later(this, this._syncData, 500);
       }
     });
@@ -340,7 +345,7 @@ export default class CookieStore extends BaseStore {
 
   _renewExpiration() {
     if (!isTesting()) {
-      cancel(this._renewExpirationTimeout);
+      this._renewExpirationTimeout && cancel(this._renewExpirationTimeout);
       this._renewExpirationTimeout = later(this, this._renewExpiration, 60000);
     }
     if (this._isPageVisible()) {
@@ -354,7 +359,7 @@ export default class CookieStore extends BaseStore {
     // if `cookieName` has not been renamed, `oldCookieName` will be nil
     const cookieName = this._oldCookieName || this._cookieName;
     const data = this._read(cookieName);
-    if (isPresent(data)) {
+    if (data && typeof data === 'string') {
       const expiration = this._calculateExpirationTime();
       this._write(data, expiration);
     }

--- a/packages/ember-simple-auth/src/session-stores/ephemeral.ts
+++ b/packages/ember-simple-auth/src/session-stores/ephemeral.ts
@@ -11,8 +11,10 @@ import BaseStore from './base';
   @public
 */
 export default class EphemeralStore extends BaseStore {
-  constructor(owner, args) {
-    super(owner, args);
+  _data = '{}';
+
+  constructor(owner: any) {
+    super(owner);
 
     this.clear();
   }
@@ -26,7 +28,7 @@ export default class EphemeralStore extends BaseStore {
     @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
-  persist(data) {
+  persist(data: Record<string, string>) {
     this._data = JSON.stringify(data || {});
 
     return Promise.resolve();
@@ -41,7 +43,7 @@ export default class EphemeralStore extends BaseStore {
     @public
   */
   restore() {
-    const data = JSON.parse(this._data) || {};
+    const data = JSON.parse(this._data || '{}');
 
     return Promise.resolve(data);
   }
@@ -55,7 +57,6 @@ export default class EphemeralStore extends BaseStore {
     @public
   */
   clear() {
-    delete this._data;
     this._data = '{}';
 
     return Promise.resolve();

--- a/packages/ember-simple-auth/src/session-stores/local-storage.ts
+++ b/packages/ember-simple-auth/src/session-stores/local-storage.ts
@@ -34,8 +34,12 @@ export default class LocalStorageStore extends BaseStore {
   */
   key = 'ember_simple_auth-session';
 
-  init() {
-    this._super(...arguments);
+  _isFastBoot: boolean = false;
+  _boundHandler: (e: any) => void;
+  _lastData: Record<string, string> | null = null;
+
+  constructor(owner: any) {
+    super(owner);
 
     this._isFastBoot = this.hasOwnProperty('_isFastBoot')
       ? this._isFastBoot
@@ -61,10 +65,10 @@ export default class LocalStorageStore extends BaseStore {
     @return {Promise} A promise that resolves when the data has successfully been persisted and rejects otherwise.
     @public
   */
-  persist(data) {
+  persist(data: Record<string, string>) {
     this._lastData = data;
-    data = JSON.stringify(data || {});
-    localStorage.setItem(this.key, data);
+    const stringifiedData = JSON.stringify(data || {});
+    localStorage.setItem(this.key, stringifiedData);
 
     return Promise.resolve();
   }
@@ -80,7 +84,7 @@ export default class LocalStorageStore extends BaseStore {
   restore() {
     let data = localStorage.getItem(this.key);
 
-    return Promise.resolve(JSON.parse(data) || {});
+    return Promise.resolve(JSON.parse(data || '{}'));
   }
 
   /**
@@ -100,7 +104,7 @@ export default class LocalStorageStore extends BaseStore {
     return Promise.resolve();
   }
 
-  _handleStorageEvent(e) {
+  _handleStorageEvent(e: StorageEvent) {
     if (e.key === this.get('key')) {
       this.restore().then(data => {
         if (!objectsAreEqual(data, this._lastData)) {


### PR DESCRIPTION
- Refactors the session-stores to typescript

An interesting thing I found here is that the cookie session-store **must** use `init` method instead of a constructor because of some initialization timing issues.
Tests extend these classes and change some fields where changing `init` to `constructor` changes the behavior.