### PR TITLE
feat(ember-simple-auth): implement internal EventTarget

### DIFF
--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -62,8 +62,7 @@
     "prettier": "3.3.3",
     "rollup": "4.25.0",
     "rollup-plugin-copy": "3.5.0",
-    "typescript": "^5.7.2",
-    "typescript-event-target": "^1.1.1"
+    "typescript": "^5.7.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -79,7 +78,6 @@
       "./initializers/ember-simple-auth.js": "./dist/_app_/initializers/ember-simple-auth.js",
       "./services/session.js": "./dist/_app_/services/session.js",
       "./session-stores/application.js": "./dist/_app_/session-stores/application.js",
-      "./utils/inject.js": "./dist/_app_/utils/inject.js",
       "./utils/is-fastboot.js": "./dist/_app_/utils/is-fastboot.js",
       "./utils/location.js": "./dist/_app_/utils/location.js",
       "./utils/objects-are-equal.js": "./dist/_app_/utils/objects-are-equal.js"

--- a/packages/ember-simple-auth/src/-internals/event-target.ts
+++ b/packages/ember-simple-auth/src/-internals/event-target.ts
@@ -1,0 +1,42 @@
+import EmberObject from '@ember/object';
+import Evented from '@ember/object/evented';
+
+export type EventListener<Events, Event extends keyof Events> = (event: Events[Event]) => void;
+
+type ValueIsEvent<T> = {
+  [key in keyof T]: CustomEvent;
+};
+
+/**
+ * This module exists to act as a 'shim' between Native EventTarget API, which unfortunately can't be used due to Fastboot's node environment not providing it.
+ *
+ * It more-or-less implements the same API as an EventTarget would have but on top of Evented mixin instead.
+ */
+export default class EsaEventTarget<Events extends ValueIsEvent<Events>> extends EmberObject.extend(
+  Evented
+) {
+  addEventListener<Event extends keyof Events & string>(
+    event: Event,
+    cb: EventListener<Events, Event>
+  ) {
+    (this as any).on(event, cb);
+  }
+
+  removeEventListener<Event extends keyof Events & string>(
+    event: Event,
+    cb: EventListener<Events, Event>
+  ) {
+    (this as any).off(event, cb);
+  }
+
+  dispatchEvent<Event extends keyof Events & string>(event: Event, value: Events[Event]['detail']) {
+    // let customEvent: CustomEvent;
+    // if (value) {
+    //   customEvent = new CustomEvent(event, { detail: value });
+    // } else {
+    //   customEvent = new CustomEvent(event);
+    // }
+
+    (this as any).trigger(event, { detail: value });
+  }
+}

--- a/packages/ember-simple-auth/src/authenticators/base.ts
+++ b/packages/ember-simple-auth/src/authenticators/base.ts
@@ -1,12 +1,12 @@
 import EmberObject from '@ember/object';
-import { TypedEventTarget, type TypedEventListener } from 'typescript-event-target';
+import EsaEventTarget, { type EventListener } from '../-internals/event-target';
 
 export interface AuthenticatorEvents {
   sessionDataUpdated: CustomEvent<any>;
   sessionDataInvalidated: CustomEvent;
 }
 
-class AuthenticatorEventTarget extends TypedEventTarget<AuthenticatorEvents> {}
+class AuthenticatorEventTarget extends EsaEventTarget<AuthenticatorEvents> {}
 
 /**
   The base class for all authenticators. __This serves as a starting point for
@@ -175,29 +175,22 @@ export default class EsaBaseAuthenticator extends EmberObject {
 
   on<Event extends keyof AuthenticatorEvents>(
     event: Event,
-    cb: TypedEventListener<AuthenticatorEvents, Event>
+    cb: EventListener<AuthenticatorEvents, Event>
   ) {
-    this.authenticatorEvents.addEventListener(event, cb);
+    this.authenticatorEvents.addEventListener(event, cb as any);
   }
 
   off<Event extends keyof AuthenticatorEvents>(
     event: Event,
-    cb: TypedEventListener<AuthenticatorEvents, Event>
+    cb: EventListener<AuthenticatorEvents, Event>
   ) {
-    this.authenticatorEvents.removeEventListener(event, cb);
+    this.authenticatorEvents.removeEventListener(event, cb as any);
   }
 
   trigger<Event extends keyof AuthenticatorEvents>(
     event: Event,
     value: AuthenticatorEvents[Event]['detail']
   ) {
-    let customEvent;
-    if (value) {
-      customEvent = new CustomEvent(event, { detail: value });
-    } else {
-      customEvent = new CustomEvent(event);
-    }
-
-    this.authenticatorEvents.dispatchTypedEvent(event, customEvent);
+    this.authenticatorEvents.dispatchEvent(event, value);
   }
 }

--- a/packages/ember-simple-auth/src/session-stores/base.ts
+++ b/packages/ember-simple-auth/src/session-stores/base.ts
@@ -1,11 +1,11 @@
 import EmberObject from '@ember/object';
-import { TypedEventTarget, type TypedEventListener } from 'typescript-event-target';
+import EsaEventTarget, { type EventListener } from '../-internals/event-target';
 
 export interface SessionEvents {
   sessionDataUpdated: CustomEvent<any>;
 }
 
-class SessionStoreEventTarget extends TypedEventTarget<SessionEvents> {}
+class SessionStoreEventTarget extends EsaEventTarget<SessionEvents> {}
 
 /**
   The base class for all session stores. __This serves as a starting point for
@@ -79,28 +79,15 @@ export default class EsaBaseSessionStore extends EmberObject {
     return Promise.reject();
   }
 
-  on<Event extends keyof SessionEvents>(
-    event: Event,
-    cb: TypedEventListener<SessionEvents, Event>
-  ) {
+  on<Event extends keyof SessionEvents>(event: Event, cb: EventListener<SessionEvents, Event>) {
     this.sessionStoreEvents.addEventListener(event, cb);
   }
 
-  off<Event extends keyof SessionEvents>(
-    event: Event,
-    cb: TypedEventListener<SessionEvents, Event>
-  ) {
+  off<Event extends keyof SessionEvents>(event: Event, cb: EventListener<SessionEvents, Event>) {
     this.sessionStoreEvents.removeEventListener(event, cb);
   }
 
   trigger<Event extends keyof SessionEvents>(event: Event, value: SessionEvents[Event]['detail']) {
-    let customEvent;
-    if (value) {
-      customEvent = new CustomEvent(event, { detail: value });
-    } else {
-      customEvent = new CustomEvent(event);
-    }
-
-    this.sessionStoreEvents.dispatchTypedEvent(event, customEvent);
+    this.sessionStoreEvents.dispatchEvent(event, value);
   }
 }

--- a/packages/ember-simple-auth/src/session-stores/session-storage.ts
+++ b/packages/ember-simple-auth/src/session-stores/session-storage.ts
@@ -1,8 +1,8 @@
-import { bind } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
 import isFastBoot from '../utils/is-fastboot';
+import { action } from '@ember/object';
 
 /**
   Session store that persists data in the browser's `sessionStorage`.
@@ -30,7 +30,6 @@ export default class SessionStorageStore extends BaseStore {
   */
   key = 'ember_simple_auth-session';
   _isFastBoot: boolean = false;
-  _boundHandler: (e: any) => void;
   _lastData: Record<string, string> | null = null;
 
   constructor(owner: any) {
@@ -39,15 +38,14 @@ export default class SessionStorageStore extends BaseStore {
     this._isFastBoot = this.hasOwnProperty('_isFastBoot')
       ? this._isFastBoot
       : isFastBoot(getOwner(this));
-    this._boundHandler = bind(this, this._handleStorageEvent);
     if (!this.get('_isFastBoot')) {
-      window.addEventListener('storage', this._boundHandler);
+      window.addEventListener('storage', this._handleStorageEvent);
     }
   }
 
   willDestroy() {
     if (!this.get('_isFastBoot')) {
-      window.removeEventListener('storage', bind(this, this._handleStorageEvent));
+      window.removeEventListener('storage', this._handleStorageEvent);
     }
   }
 
@@ -99,6 +97,7 @@ export default class SessionStorageStore extends BaseStore {
     return Promise.resolve();
   }
 
+  @action
   _handleStorageEvent(e: StorageEvent) {
     if (e.key === this.get('key')) {
       this.restore().then(data => {

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -48,7 +48,7 @@
     "ember-maybe-import-regenerator": "1.0.0",
     "ember-qunit": "7.0.0",
     "ember-resolver": "11.0.1",
-    "ember-simple-auth": "6.1.0",
+    "ember-simple-auth": "workspace:*",
     "ember-source": "5.12.0",
     "ember-source-channel-url": "3.0.0",
     "ember-try": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,9 +322,6 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
-      typescript-event-target:
-        specifier: ^1.1.1
-        version: 1.1.1
 
   packages/test-app:
     dependencies:
@@ -426,8 +423,8 @@ importers:
         specifier: 11.0.1
         version: 11.0.1(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.96.1))
       ember-simple-auth:
-        specifier: 6.1.0
-        version: 6.1.0(@babel/core@7.26.0)(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.96.1))(webpack@5.96.1))(@glint/template@1.5.0)(eslint@8.57.1)
+        specifier: workspace:*
+        version: link:../ember-simple-auth
       ember-source:
         specifier: 5.12.0
         version: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.96.1)
@@ -9332,9 +9329,6 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
-  typescript-event-target@1.1.1:
-    resolution: {integrity: sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==}
-
   typescript-memoize@1.1.1:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
@@ -13731,26 +13725,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/ember@4.0.11':
-    dependencies:
-      '@types/ember__application': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__array': 4.0.10(@babel/core@7.26.0)
-      '@types/ember__component': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__controller': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__debug': 4.0.8(@babel/core@7.26.0)
-      '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__error': 4.0.6
-      '@types/ember__object': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__polyfills': 4.0.6
-      '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__runloop': 4.0.10
-      '@types/ember__service': 4.0.9(@babel/core@7.26.0)
-      '@types/ember__string': 3.0.15
-      '@types/ember__template': 4.0.7
-      '@types/ember__test': 4.0.6(@babel/core@7.26.0)
-      '@types/ember__utils': 4.0.7
-      '@types/rsvp': 4.0.9
-
   '@types/ember@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.26.0)
@@ -13777,7 +13751,7 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
-      '@types/ember': 4.0.11
+      '@types/ember': 4.0.11(@babel/core@7.26.0)
       '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__owner': 4.0.9
@@ -13849,10 +13823,6 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@types/ember__runloop@4.0.10':
-    dependencies:
-      '@types/ember': 4.0.11
-
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.26.0)
@@ -13877,10 +13847,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-
-  '@types/ember__utils@4.0.7':
-    dependencies:
-      '@types/ember': 4.0.11
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':
     dependencies:
@@ -17222,23 +17188,6 @@ snapshots:
       silent-error: 1.1.1
     optionalDependencies:
       '@ember/test-helpers': 3.3.1(@babel/core@7.25.2)(@glint/template@1.5.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.96.1))(webpack@5.96.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - eslint
-      - supports-color
-
-  ember-simple-auth@6.1.0(@babel/core@7.26.0)(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.96.1))(webpack@5.96.1))(@glint/template@1.5.0)(eslint@8.57.1):
-    dependencies:
-      '@babel/eslint-parser': 7.25.1(@babel/core@7.26.0)(eslint@8.57.1)
-      '@ember/test-waiters': 3.1.0
-      '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.6(@glint/template@1.5.0)
-      ember-cli-is-package-missing: 1.0.0
-      ember-cookies: 1.1.2
-      silent-error: 1.1.1
-    optionalDependencies:
-      '@ember/test-helpers': 3.3.1(@babel/core@7.26.0)(@glint/template@1.5.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.96.1))(webpack@5.96.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -22562,8 +22511,6 @@ snapshots:
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
-
-  typescript-event-target@1.1.1: {}
 
   typescript-memoize@1.1.1: {}
 


### PR DESCRIPTION
- Reimplements #2875 
The previous PR removed Evented mixin that was used by the classes directly - which is a nice improvement and allows full conversion to native classes.
- Changes test app to refer to ember-simple-auth as `workspace:*` instead of a version.
- Refactors ember runloop inline `bind` when providing methods to event listeners, to decorating methods directly 

Unfortunately extending from the native EventTarget such as `class MyClass extends EventTarget` fails under fastboot and presumably when typescript's involved too. The #2875 seemed to work fine unless typescript was involved.
The issue isn't related to the `typescript-event-target` package that was introduced instead of Evented.

Maybe our Fastboot & Typescript herald @mansona would know more?

Some error details after running `pnpm -F test-app test:one ember-4.0` on `exp` branch which still contains changes from #2875  and introduces Typescript to a test-app project.
https://github.com/mainmatter/ember-simple-auth/compare/master...exp



>Built project successfully. Stored in "/tmp/tests-dist-20241128-528226-paejhx.luctg".
webpack://__ember_auto_import__/../ember-simple-auth/dist/index-B7bj3ruc.js?:5
var e=class extends EventTarget{dispatchTypedEvent(s,t){return super.dispatchEvent(t);}};
      ^

> ReferenceError: EventTarget is not defined
    at eval (webpack://__ember_auto_import__/../ember-simple-auth/dist/index-B7bj3ruc.js?:5:7)
    at Module.../ember-simple-auth/dist/index-B7bj3ruc.js (/tmp/tests-dist-20241128-528226-paejhx.luctg/assets/chunk.tmp_broccoli-528226IU5dTQgKbam2_cache-370-webpack_bundler_ember_auto_import_webpack_app_cjs-t-c22a03.d212ee7a3f9e690f2962.js:84:1)
    at __webpack_require__ (/tmp/tests-dist-20241128-528226-paejhx.luctg/assets/chunk.app.77ba3811edadbb926032.js:164:42)
    at eval (webpack://__ember_auto_import__/../ember-simple-auth/dist/session-stores/base.js?:8:76)
    at Module.../ember-simple-auth/dist/session-stores/base.js (/tmp/tests-dist-20241128-528226-paejhx.luctg/assets/chunk.tmp_broccoli-528226IU5dTQgKbam2_cache-370-webpack_bundler_ember_auto_import_webpack_app_cjs-t-c22a03.d212ee7a3f9e690f2962.js:139:1)
    at __webpack_require__ (/tmp/tests-dist-20241128-528226-paejhx.luctg/assets/chunk.app.77ba3811edadbb926032.js:164:42)
    at eval (webpack://__ember_auto_import__/../ember-simple-auth/dist/session-stores/ephemeral.js?:6:66)
    at Module.../ember-simple-auth/dist/session-stores/ephemeral.js (/tmp/tests-dist-20241128-528226-paejhx.luctg/assets/chunk.tmp_broccoli-528226IU5dTQgKbam2_cache-370-webpack_bundler_ember_auto_import_webpack_app_cjs-t-c22a03.d212ee7a3f9e690f2962.js:161:1)
    at __webpack_require__ (/tmp/tests-dist-20241128-528226-paejhx.luctg/assets/chunk.app.77ba3811edadbb926032.js:164:42)
    at eval (webpack://__ember_auto_import__/../ember-simple-auth/dist/initializers/setup-session.js?:15:86)
    at Module.../ember-simple-auth/dist/initializers/setup-session.js (/tmp/tests-dist-20241128-528226-paejhx.luctg/assets/chunk.tmp_broccoli-528226IU5dTQgKbam2_cache-370-webpack_bundler_ember_auto_import_webpack_app_cjs-t-c22a03.d212ee7a3f9e690f2962.js:106:1)
