### PR TITLE
chore(ember-simple-auth): specify addon exports

### DIFF
--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -84,17 +84,45 @@
     }
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./*": "./dist/*.js",
-    "./authenticators/oauth2-password-grant": "./dist/authenticators/oauth2-password-grant.js",
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./declarations/index.d.ts"
+    },
+    "./*": {
+      "default": "./dist/*.js",
+      "types": "./declarations/*.d.ts"
+    },
     "./addon-main.js": "./addon-main.cjs",
+    "./authenticators/*": {
+      "default": "./dist/authenticators/*.js",
+      "types": "./declarations/authenticators/*.d.ts"
+    },
+    "./initializers/*": {
+      "default": "./dist/initializers/*.js",
+      "types": "./declarations/initializers/*.d.ts"
+    },
+    "./services/session": {
+      "default": "./dist/services/session.js",
+      "types": "./declarations/services/session.d.ts"
+    },
+    "./session-stores/*": {
+      "default": "./dist/session-stores/*.js",
+      "types": "./declarations/session-stores/*.d.ts"
+    },
     "./test-support": {
-      "types": "./declarations/test-support/*.d.ts",
-      "default": "./dist/test-support/index.js"
+      "default": "./dist/test-support/index.js",
+      "types": "./declarations/test-support/*.d.ts"
     },
     "./utils/*": {
-      "types": "./dist/utils/*.d.ts",
-      "default": "./dist/utils/*.js"
+      "default": "./dist/utils/*.js",
+      "types": "./declarations/utils/*.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./declarations/*.d.ts"
+      ]
     }
   },
   "peerDependencies": {

--- a/packages/ember-simple-auth/rollup.config.mjs
+++ b/packages/ember-simple-auth/rollup.config.mjs
@@ -22,6 +22,7 @@ export default {
     addon.publicEntrypoints([
       'services/**/*.js',
       'session-stores/**/*.js',
+      'utils/is-fastboot.js',
       'utils/**/*.js',
       'authenticators/**/*.js',
       'test-support/**/*.js',

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -59,7 +59,7 @@ type InternalSessionMock = {
   @extends Service
   @public
 */
-export default class EmberSimpleAuthSessionService extends Service {
+export default class SessionService extends Service {
   session: InternalSessionMock;
 
   constructor(owner: any) {


### PR DESCRIPTION
- Specifies `ember-simple-auth` "exports" inside package.json.
- Renames `EmberSimpleAuthSessionService` to `SessionService`.