### PR TITLE
feat(ember-simple-auth): remove app re-exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,23 @@ as well as prepare yourself for v5 release which will make it **required**.
 
 ## Walkthrough
 
-Once the library is installed, __the session service can be injected wherever
+Once the library is installed, import a session service and a session-store inside your application__.
+
+### Add `app/services/session.js` or `app/services/session.ts`
+```js
+import Service from 'ember-simple-auth/services/session';
+
+export default class SessionService extends Service {}
+```
+
+### Add `app/session-stores/application.js` or `app/session-stores/application.ts`
+```js
+import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
+
+export default class SessionStore extends AdaptiveStore {}
+```
+
+then __the session service can be injected wherever
 needed in the application__. In order to display login/logout buttons depending
 on the current session state, inject the service into the respective controller
 or component and __query its

--- a/guides/upgrade-to-v7.md
+++ b/guides/upgrade-to-v7.md
@@ -1,10 +1,12 @@
-### tl;dr
+## tl;dr
 
 Release 7.0.0 doesn't contain any new features and the API haven't really changed.
 It focuses on housekeeping, modernizing the codebase and introducing Typescript to our library.
 The biggest change was getting rid of as much "classic" Ember syntax as possible and get onto ES6 classes.
 
-### Extending ember-simple-auth's classes
+There are some not-so-painful breaking changes however, please refer to the following document.
+
+## Extending ember-simple-auth's classes
 
 Most if not all of the public API is ES6 classes, as a result you'll have to change how ESA's classes are extended in your codebases.
 Here's an example based on the OAuth2PasswordGrant authenticator.
@@ -31,4 +33,29 @@ export default class OAuth2 extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${config.apiHost}/token`;
   serverTokenRevocationEndpoint = `${config.apiHost}/revoke`;
 }
+```
+
+## Default session-store and service are no longer automatically injected.
+
+This change is made due to processing problems found here [ember-simple-auth/#2888](https://github.com/mainmatter/ember-simple-auth/pull/2888) and [shipshapecode/swach#1736](https://github.com/shipshapecode/swach/pull/1736).
+It's been a problem for a long time and with Ember-Data and Ember itself being more explicit around dependencies, we're making the change too.
+
+The only thing that ESA will continue to export is the initializer, they aren't usually imported and extended by users so they shouldn't cause problems as long as Ember still supports it.
+
+### Migration guide:
+
+Add `app/services/session.js` or `app/services/session.ts`
+
+```js
+import Service from 'ember-simple-auth/services/session';
+
+export default class SessionService extends Service {}
+```
+
+Add `app/session-stores/application.js` or `app/session-stores/application.ts`
+
+```js
+import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
+
+export default class SessionStore extends AdaptiveStore {}
 ```

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -74,12 +74,7 @@
     "type": "addon",
     "main": "addon-main.cjs",
     "app-js": {
-      "./initializers/ember-simple-auth.js": "./dist/_app_/initializers/ember-simple-auth.js",
-      "./services/session.js": "./dist/_app_/services/session.js",
-      "./session-stores/application.js": "./dist/_app_/session-stores/application.js",
-      "./utils/is-fastboot.js": "./dist/_app_/utils/is-fastboot.js",
-      "./utils/location.js": "./dist/_app_/utils/location.js",
-      "./utils/objects-are-equal.js": "./dist/_app_/utils/objects-are-equal.js"
+      "./initializers/ember-simple-auth.js": "./dist/_app_/initializers/ember-simple-auth.js"
     }
   },
   "exports": {

--- a/packages/ember-simple-auth/rollup.config.mjs
+++ b/packages/ember-simple-auth/rollup.config.mjs
@@ -33,12 +33,7 @@ export default {
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([
-      'services/session.js',
-      'utils/**/*.js',
-      'session-stores/application.js',
-      'initializers/ember-simple-auth.js',
-    ]),
+    addon.appReexports(['initializers/ember-simple-auth.js']),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided

--- a/packages/test-esa/app/services/session.js
+++ b/packages/test-esa/app/services/session.js
@@ -1,0 +1,3 @@
+import Service from 'ember-simple-auth/services/session';
+
+export default class SessionService extends Service {}

--- a/packages/test-esa/app/session-stores/application.js
+++ b/packages/test-esa/app/session-stores/application.js
@@ -1,0 +1,3 @@
+import Adaptive from 'ember-simple-auth/session-stores/adaptive';
+
+export default class AdaptiveStore extends Adaptive {}


### PR DESCRIPTION
- Removes app re-exports , meaning that Ember-Simple-Auth will no longer automatically add `services/session` and `session-stores/application` files. 
They must be imported by users themselves.

This change is made due to processing problems found here https://github.com/mainmatter/ember-simple-auth/pull/2888 and https://github.com/shipshapecode/swach/pull/1736. 
It's been a problem for a long time and with Ember-Data and Ember itself being more explicit around dependencies, we should make the switch too.

The only thing that ESA will continue to export is the initializer, they aren't usually imported and extended by users so they shouldn't cause problems as long as Ember still supports it.


## Migration guide:

Add `app/services/session.js` or `app/services/session.ts`
```js
import Service from 'ember-simple-auth/services/session';

export default class SessionService extends Service {}
```

Add `app/session-stores/application.js` or `app/session-stores/application.ts`
```js
import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';

export default class SessionStore extends AdaptiveStore {}
```