### PR TITLE
Addon dependency maintenance

### DIFF
--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -32,9 +32,7 @@
     "@ember/test-waiters": "^3",
     "@embroider/addon-shim": "^1.0.0",
     "@embroider/macros": "^1.0.0",
-    "ember-cli-is-package-missing": "^1.0.0",
-    "ember-cookies": "^1.3.0",
-    "silent-error": "^1.0.0"
+    "ember-cookies": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.26.9",

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -29,7 +29,7 @@
     "release": "npm publish"
   },
   "dependencies": {
-    "@ember/test-waiters": "^3",
+    "@ember/test-waiters": "^3 || ^4",
     "@embroider/addon-shim": "^1.0.0",
     "@embroider/macros": "^1.0.0",
     "ember-cookies": "^1.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
         specifier: '>= 3 || > 2.7'
         version: 3.3.1(@babel/core@7.26.9)(@glint/template@1.5.2)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1)
       '@ember/test-waiters':
-        specifier: ^3
+        specifier: ^3 || ^4
         version: 3.1.0
       '@embroider/addon-shim':
         specifier: ^1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,18 +236,12 @@ importers:
       '@embroider/macros':
         specifier: ^1.0.0
         version: 1.16.10(@glint/template@1.5.2)
-      ember-cli-is-package-missing:
-        specifier: ^1.0.0
-        version: 1.0.0
       ember-cookies:
         specifier: ^1.3.0
         version: 1.3.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1))
       ember-source:
         specifier: '>=4.0'
         version: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1)
-      silent-error:
-        specifier: ^1.0.0
-        version: 1.1.1
     devDependencies:
       '@babel/core':
         specifier: 7.26.9


### PR DESCRIPTION
- remove `silent-error` and `ember-cli-is-package-missing` since they are no longer used
- add support for [`@ember/test-waiters` v4](https://github.com/emberjs/ember-test-waiters/blob/3f977b5d9f2c4f6fe051b0b41e8c30ca367b4045/CHANGELOG.md#release-2024-12-05) which allows apps to use v4 without using overrides