### PR TITLE
breaking(esa): drop all end of life versions until March 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,6 @@ jobs:
           - classic-test-app
           - test-app
         test-suite:
-          - test:one ember-lts-3.28
-          - test:one ember-lts-4.4
-          - test:one ember-lts-4.8
           - test:one ember-lts-4.12
           - test:one ember-lts-5.4
           - test:one ember-lts-5.8

--- a/packages/test-esa/config/ember-try.js
+++ b/packages/test-esa/config/ember-try.js
@@ -16,38 +16,6 @@ module.exports = function () {
       usePnpm: true,
       scenarios: [
         {
-          name: 'ember-lts-3.28',
-          npm: {
-            devDependencies: {
-              'ember-cli': '~3.28.0',
-              'ember-data': '~3.28.0',
-              'ember-source': '~3.28.0',
-              'ember-qunit': '~6.0.0',
-              '@ember/test-helpers': '~2.7.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-4.4',
-          npm: {
-            devDependencies: {
-              'ember-cli': '~4.4.0',
-              'ember-data': '~4.4.0',
-              'ember-source': '~4.4.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-4.8',
-          npm: {
-            devDependencies: {
-              'ember-cli': '~4.8.0',
-              'ember-data': '~4.8.2',
-              'ember-source': '~4.8.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-4.12',
           npm: {
             devDependencies: {


### PR DESCRIPTION
- Drops support for all End Of Life versions until March 2025.
   `4.12` is the minimal version we'll officially support.
- Drops Ember < 4.1 https://github.com/mainmatter/ember-simple-auth/pull/2954

Ember >= 4.1 should continue to work, but we'll no longer run CI for most of the versions.