### PR TITLE
incorrect credentials doesn't show data-test-error-message

### DIFF
--- a/packages/test-app/app/components/login-form.js
+++ b/packages/test-app/app/components/login-form.js
@@ -25,8 +25,7 @@ export default class LoginFormComponent extends Component {
         this.session.set('store.cookieExpirationTime', null);
       }
     } catch (response) {
-      let responseBody = await response.clone().json();
-      this.errorMessage = responseBody;
+      this.errorMessage = response.responseJSON.error;
     }
   }
 


### PR DESCRIPTION
Resolves error when trying to log in with with incorrect credentials: "Uncaught (in promise) TypeError: Response.clone: Body has already been consumed."