### PR TITLE
Refactor: InternalSession native class (extends EmberObject still)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ authorization mechanisms__.
 
 * [Managing a current User](guides/managing-current-user.md)
 * [GitHub authorization with torii](guides/auth-torii-with-github.md)
+* [Upgrading to v9](guides/upgrade-to-v9.md)
 * [Upgrading to v7](guides/upgrade-to-v7.md)
 * [Upgrading to v4](guides/upgrade-to-v4.md)
 * [Upgrading to v3](guides/upgrade-to-v3.md)
@@ -740,6 +741,7 @@ If you're an `ember-mocha` user, we can recommend to check out this
 ## Other guides
 
 * [Managing current User](guides/managing-current-user.md)
+* [Upgrading to v9](guides/upgrade-to-v9.md)
 * [Upgrading to v7](guides/upgrade-to-v7.md)
 * [Upgrading to v4](guides/upgrade-to-v4.md)
 * [Upgrading to v3](guides/upgrade-to-v3.md)

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -4,14 +4,11 @@ v9 removes resolver-based `session:main` wiring. The session service owns `Inter
 
 ## `session:main` resolver registration
 
-Assign an `InternalSession` on your session service instead of looking it up via `session:main`.
+Set `useInternalSessionLookup` to `false` so the session service constructs `InternalSession` and `session:main` is not registered.
 
 ```js
-import { getOwner } from '@ember/application';
-import Service from 'ember-simple-auth/services/session';
-import InternalSession from 'ember-simple-auth/internal-session';
-
-export default class SessionService extends Service {
-  session = new InternalSession(getOwner(this));
-}
+// config/environment.js
+ENV['ember-simple-auth'] = {
+  useInternalSessionLookup: false,
+};
 ```

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -1,0 +1,16 @@
+## tl;dr
+
+v9 removes resolver-based `session:main` wiring. The session service owns `InternalSession` directly.
+
+## `session:main` resolver registration
+
+Assign an `InternalSession` on your session service instead of looking it up via `session:main`.
+
+```js
+import SessionService from 'ember-simple-auth/services/session';
+import InternalSession from 'ember-simple-auth/internal-session';
+
+export default class extends SessionService {
+  session = InternalSession.create(this);
+}
+```

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -7,10 +7,11 @@ v9 removes resolver-based `session:main` wiring. The session service owns `Inter
 Assign an `InternalSession` on your session service instead of looking it up via `session:main`.
 
 ```js
-import SessionService from 'ember-simple-auth/services/session';
+import { getOwner } from '@ember/application';
+import Service from 'ember-simple-auth/services/session';
 import InternalSession from 'ember-simple-auth/internal-session';
 
-export default class extends SessionService {
-  session = InternalSession.create(this);
+export default class SessionService extends Service {
+  session = new InternalSession(getOwner(this));
 }
 ```

--- a/packages/ember-simple-auth/rollup.config.mjs
+++ b/packages/ember-simple-auth/rollup.config.mjs
@@ -28,6 +28,7 @@ export default {
       'test-support/**/*.js',
       'configuration.js',
       'initializers/**/*.js',
+      'internal-session.js',
     ]),
 
     // These are the modules that should get reexported into the traditional

--- a/packages/ember-simple-auth/src/configuration.js
+++ b/packages/ember-simple-auth/src/configuration.js
@@ -1,6 +1,7 @@
 const DEFAULTS = {
   rootURL: '',
   routeAfterAuthentication: 'index',
+  useInternalSessionLookup: true,
 };
 
 /**
@@ -36,11 +37,28 @@ export default {
   */
   routeAfterAuthentication: DEFAULTS.routeAfterAuthentication,
 
+  /**
+    When `true`, the session service looks up `session:main` from the resolver.
+    When `false`, the session service constructs `InternalSession` itself.
+
+    @memberof Configuration
+    @property useInternalSessionLookup
+    @static
+    @type Boolean
+    @default true
+    @public
+  */
+  useInternalSessionLookup: DEFAULTS.useInternalSessionLookup,
+
   load(config) {
     this.rootURL = config.rootURL !== undefined ? config.rootURL : DEFAULTS.rootURL;
     this.routeAfterAuthentication =
       config.routeAfterAuthentication !== undefined
         ? config.routeAfterAuthentication
         : DEFAULTS.routeAfterAuthentication;
+    this.useInternalSessionLookup =
+      config.useInternalSessionLookup !== undefined
+        ? config.useInternalSessionLookup
+        : DEFAULTS.useInternalSessionLookup;
   },
 };

--- a/packages/ember-simple-auth/src/initializers/setup-session.js
+++ b/packages/ember-simple-auth/src/initializers/setup-session.js
@@ -1,9 +1,12 @@
 import InternalSession from '../internal-session';
 import Ephemeral from '../session-stores/ephemeral';
 import { isTesting } from '@embroider/macros';
+import Configuration from '../configuration';
 
 export default function setupSession(registry) {
-  registry.register('session:main', InternalSession);
+  if (Configuration.useInternalSessionLookup) {
+    registry.register('session:main', InternalSession);
+  }
 
   if (isTesting()) {
     registry.register('session-store:test', Ephemeral);

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -44,7 +44,7 @@ export default class InternalSession extends EmberObject {
     @private
   */
   authenticator = null;
-  content = null;
+  content = { authenticated: {} };
   store = null;
   isAuthenticated = false;
   attemptedTransition = null;

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -15,7 +15,7 @@ class SessionEventTarget extends EsaEventTarget {}
   @private
 */
 
-const InternalSession = EmberObject.extend({
+export default class InternalSession extends EmberObject {
   /**
     Triggered whenever the session is successfully authenticated. This happens
     when the session gets authenticated via
@@ -43,16 +43,17 @@ const InternalSession = EmberObject.extend({
     @event invalidationSucceeded
     @private
   */
-  authenticator: null,
-  content: null,
-  store: null,
-  isAuthenticated: false,
-  attemptedTransition: null,
-  sessionEvents: null,
-  redirectTarget: null,
+  authenticator = null;
+  content = null;
+  store = null;
+  isAuthenticated = false;
+  attemptedTransition = null;
+  sessionEvents = null;
+  redirectTarget = null;
 
-  init() {
-    this._super(...arguments);
+  constructor(owner) {
+    super(owner);
+
     this.set('content', { authenticated: {} });
     let storeFactory = 'session-store:application';
     if (isTesting()) {
@@ -63,7 +64,7 @@ const InternalSession = EmberObject.extend({
     this.set('store', getOwner(this).lookup(storeFactory));
     this._busy = false;
     this._bindToStoreEvents();
-  },
+  }
 
   authenticate(authenticatorFactory, ...args) {
     this._busy = true;
@@ -85,7 +86,7 @@ const InternalSession = EmberObject.extend({
         return this._clear().then(rejectWithError, rejectWithError);
       }
     );
-  },
+  }
 
   invalidate() {
     this._busy = true;
@@ -109,7 +110,7 @@ const InternalSession = EmberObject.extend({
         return Promise.reject(error);
       }
     );
-  },
+  }
 
   restore() {
     this._busy = true;
@@ -149,7 +150,7 @@ const InternalSession = EmberObject.extend({
         return this._clear().then(reject, reject);
       }
     );
-  },
+  }
 
   _setup(authenticator, authenticatedContent, trigger) {
     trigger = Boolean(trigger) && !this.get('isAuthenticated');
@@ -174,7 +175,7 @@ const InternalSession = EmberObject.extend({
         });
       }
     );
-  },
+  }
 
   _clear(trigger) {
     trigger = Boolean(trigger) && this.get('isAuthenticated');
@@ -189,18 +190,18 @@ const InternalSession = EmberObject.extend({
         this.trigger('invalidationSucceeded');
       }
     });
-  },
+  }
 
   _clearWithContent(content, trigger) {
     this.set('content', content);
     return this._clear(trigger);
-  },
+  }
 
   // ObjectProxy shim for content key delegation.
   unknownProperty(key) {
     let content = get(this, 'content');
     return content ? get(content, key) : undefined;
-  },
+  }
 
   setUnknownProperty(key, value) {
     assert('"authenticated" is a reserved key used by Ember Simple Auth!', key !== 'authenticated');
@@ -215,7 +216,7 @@ const InternalSession = EmberObject.extend({
       this._updateStore();
     }
     return result;
-  },
+  }
 
   _updateStore() {
     let data = this.content;
@@ -227,21 +228,23 @@ const InternalSession = EmberObject.extend({
       );
     }
     return this.store.persist(data);
-  },
+  }
 
   _bindToAuthenticatorEvents() {
     const authenticator = this._lookupAuthenticator(this.authenticator);
     authenticator.on('sessionDataUpdated', this._onSessionDataUpdated);
     authenticator.on('sessionDataInvalidated', this._onSessionDataInvalidated);
-  },
+  }
 
-  _onSessionDataUpdated: action(function ({ detail: content }) {
+  @action
+  _onSessionDataUpdated({ detail: content }) {
     this._setup(this.authenticator, content);
-  }),
+  }
 
-  _onSessionDataInvalidated: action(function () {
+  @action
+  _onSessionDataInvalidated() {
     this._clear(true);
-  }),
+  }
 
   _bindToStoreEvents() {
     this.store.on('sessionDataUpdated', ({ detail: content }) => {
@@ -274,7 +277,7 @@ const InternalSession = EmberObject.extend({
         }
       }
     });
-  },
+  }
 
   _lookupAuthenticator(authenticatorName) {
     let owner = getOwner(this);
@@ -285,43 +288,29 @@ const InternalSession = EmberObject.extend({
     );
     setOwner(authenticator, owner);
     return authenticator;
-  },
+  }
 
   on(event, cb) {
     this.sessionEvents.addEventListener(event, cb);
-  },
+  }
 
   off(event, cb) {
     this.sessionEvents.removeEventListener(event, cb);
-  },
+  }
 
   trigger(event, value) {
     this.sessionEvents.dispatchEvent(event, value);
-  },
+  }
 
   setRedirectTarget(url) {
     this.store.setRedirectTarget?.(url);
-  },
+  }
 
   getRedirectTarget() {
     return this.store.getRedirectTarget?.();
-  },
+  }
 
   clearRedirectTarget() {
     return this.store.clearRedirectTarget?.();
-  },
-});
-
-InternalSession.reopenClass({
-  create(parent, ...rest) {
-    let owner = parent && (getOwner(parent) || (typeof parent.lookup === 'function' ? parent : null));
-
-    if (owner) {
-      return this._super(owner.ownerInjection(), ...rest);
-    }
-
-    return this._super(...arguments);
-  },
-});
-
-export default InternalSession;
+  }
+}

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -1,6 +1,5 @@
 import { isEmpty, isNone } from '@ember/utils';
-import ObjectProxy from '@ember/object/proxy';
-import { action, set } from '@ember/object';
+import EmberObject, { action, get, set } from '@ember/object';
 import { debug, assert } from '@ember/debug';
 import { getOwner, setOwner } from '@ember/application';
 import { isTesting } from '@embroider/macros';
@@ -12,11 +11,11 @@ class SessionEventTarget extends EsaEventTarget {}
   __An internal implementation of Session. Communicates with stores and emits events.__
 
   @class InternalSession
-  @extends ObjectProxy
+  @extends EmberObject
   @private
 */
 
-export default ObjectProxy.extend({
+const InternalSession = EmberObject.extend({
   /**
     Triggered whenever the session is successfully authenticated. This happens
     when the session gets authenticated via
@@ -45,6 +44,7 @@ export default ObjectProxy.extend({
     @private
   */
   authenticator: null,
+  content: null,
   store: null,
   isAuthenticated: false,
   attemptedTransition: null,
@@ -196,9 +196,21 @@ export default ObjectProxy.extend({
     return this._clear(trigger);
   },
 
+  // ObjectProxy shim for content key delegation.
+  unknownProperty(key) {
+    let content = get(this, 'content');
+    return content ? get(content, key) : undefined;
+  },
+
   setUnknownProperty(key, value) {
     assert('"authenticated" is a reserved key used by Ember Simple Auth!', key !== 'authenticated');
-    let result = this._super(key, value);
+    let content = get(this, 'content');
+    assert(
+      `Cannot delegate set('${key}', ${value}) to the 'content' property of the internal session: its 'content' is undefined.`,
+      content
+    );
+    let result = set(content, key, value);
+    this.notifyPropertyChange(key);
     if (!/^_/.test(key)) {
       this._updateStore();
     }
@@ -299,3 +311,17 @@ export default ObjectProxy.extend({
     return this.store.clearRedirectTarget?.();
   },
 });
+
+InternalSession.reopenClass({
+  create(parent, ...rest) {
+    let owner = parent && (getOwner(parent) || (typeof parent.lookup === 'function' ? parent : null));
+
+    if (owner) {
+      return this._super(owner.ownerInjection(), ...rest);
+    }
+
+    return this._super(...arguments);
+  },
+});
+
+export default InternalSession;

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -37,8 +37,6 @@ type InternalSessionMock<Data> = {
   on: (event: 'authenticationSucceeded' | 'invalidationSucceeded', cb: () => void) => void;
   authenticate: (authenticator: string, ...args: any[]) => Promise<void>;
   invalidate: (...args: any[]) => Promise<void>;
-  requireAuthentication: (transition: Transition, routeOrCallback: RouteOrCallback) => boolean;
-  prohibitAuthentication: (routeOrCallback: RouteOrCallback) => boolean;
   restore: () => Promise<void>;
   set(key: string, value: any): void;
   setRedirectTarget: EsaBaseSessionStore['setRedirectTarget'];
@@ -78,28 +76,28 @@ export type DefaultDataShape = {
   @public
 */
 export default class SessionService<Data = DefaultDataShape> extends Service {
-  session: InternalSessionMock<Data>;
+  session!: InternalSessionMock<Data>;
 
   constructor(owner: any) {
     super(owner);
 
     if (!this.session) {
-      const resolvedSession = owner.lookup('session:main');
-      this.session = resolvedSession ?? new InternalSession(owner);
-
-      deprecate(
-        'Ember Simple Auth: session:main resolver lookup is deprecated.',
-        !resolvedSession,
-        {
+      if (Configuration.useInternalSessionLookup) {
+        this.session = owner.lookup('session:main');
+        assert('Ember Simple Auth: session:main is not registered.', this.session);
+        deprecate('Ember Simple Auth: session:main resolver lookup is deprecated.', false, {
           id: 'ember-simple-auth.session-main',
           until: '9.0.0',
           for: 'ember-simple-auth',
           since: {
+            available: '8.4.0',
             enabled: '8.4.0',
           },
           url: 'https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#sessionmain-resolver-registration',
-        }
-      );
+        });
+      } else {
+        this.session = new InternalSession(owner) as unknown as InternalSessionMock<Data>;
+      }
 
       associateDestroyableChild(this, this.session);
     }

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -85,7 +85,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
 
     if (!this.session) {
       const resolvedSession = owner.lookup('session:main');
-      this.session = resolvedSession ?? InternalSession.create(this);
+      this.session = resolvedSession ?? new InternalSession(owner);
 
       deprecate(
         'Ember Simple Auth: session:main resolver lookup is deprecated.',

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -1,7 +1,9 @@
 import Service from '@ember/service';
 import { getOwner } from '@ember/application';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
+import { associateDestroyableChild } from '@ember/destroyable';
 import Configuration from '../configuration';
+import InternalSession from '../internal-session';
 
 import {
   requireAuthentication,
@@ -81,7 +83,26 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
   constructor(owner: any) {
     super(owner);
 
-    this.session = owner.lookup('session:main');
+    if (!this.session) {
+      const resolvedSession = owner.lookup('session:main');
+      this.session = resolvedSession ?? InternalSession.create(this);
+
+      deprecate(
+        'Ember Simple Auth: session:main resolver lookup is deprecated.',
+        !resolvedSession,
+        {
+          id: 'ember-simple-auth.session-main',
+          until: '9.0.0',
+          for: 'ember-simple-auth',
+          since: {
+            enabled: '8.4.0',
+          },
+          url: 'https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#sessionmain-resolver-registration',
+        }
+      );
+
+      associateDestroyableChild(this, this.session);
+    }
   }
 
   /**

--- a/packages/test-esa/tests/unit/configuration-test.js
+++ b/packages/test-esa/tests/unit/configuration-test.js
@@ -22,6 +22,14 @@ module('Configuration', function (hooks) {
     });
   });
 
+  module('useInternalSessionLookup', function () {
+    test('defaults to true', function (assert) {
+      Configuration.load({});
+
+      assert.true(Configuration.useInternalSessionLookup);
+    });
+  });
+
   module('.load', function () {
     test('sets rootURL correctly', function (assert) {
       Configuration.load({ rootURL: '/rootURL' });
@@ -33,6 +41,12 @@ module('Configuration', function (hooks) {
       Configuration.load({ routeAfterAuthentication: '/some-route' });
 
       assert.equal(Configuration.routeAfterAuthentication, '/some-route');
+    });
+
+    test('sets useInternalSessionLookup correctly', function (assert) {
+      Configuration.load({ useInternalSessionLookup: false });
+
+      assert.false(Configuration.useInternalSessionLookup);
     });
   });
 });

--- a/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
+++ b/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
@@ -1,6 +1,22 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { registerDeprecationHandler } from '@ember/debug';
 import sinonjs from 'sinon';
+import InternalSession from 'ember-simple-auth/internal-session';
+import SessionService from 'ember-simple-auth/services/session';
+
+const SESSION_MAIN_DEPRECATION_ID = 'ember-simple-auth.session-main';
+
+function collectDeprecations() {
+  const deprecations = [];
+
+  registerDeprecationHandler((message, options, next) => {
+    deprecations.push({ message, options });
+    next(message, options);
+  });
+
+  return deprecations;
+}
 
 module('setupSessionService', function (hooks) {
   setupTest(hooks);
@@ -15,6 +31,40 @@ module('setupSessionService', function (hooks) {
   });
 
   test('injects the session into the session service', function (assert) {
+    const deprecations = collectDeprecations();
+
     assert.equal(this.owner.lookup('service:session').session, this.owner.lookup('session:main'));
+    assert.ok(
+      deprecations.some(({ options }) => options.id === SESSION_MAIN_DEPRECATION_ID),
+      'deprecates looking up session:main'
+    );
+  });
+
+  test('creates InternalSession when session:main is not registered', function (assert) {
+    this.owner.unregister('session:main');
+    const deprecations = collectDeprecations();
+
+    const service = this.owner.lookup('service:session');
+
+    assert.ok(service.session instanceof InternalSession);
+    assert.notOk(
+      deprecations.some(({ options }) => options.id === SESSION_MAIN_DEPRECATION_ID),
+      'does not deprecate when session:main is not used'
+    );
+  });
+
+  test('uses an InternalSession assigned on the session service', function (assert) {
+    this.owner.unregister('service:session');
+    this.owner.register(
+      'service:session',
+      class extends SessionService {
+        session = InternalSession.create(this);
+      }
+    );
+
+    const service = this.owner.lookup('service:session');
+
+    assert.ok(service.session instanceof InternalSession);
+    assert.notEqual(service.session, this.owner.lookup('session:main'));
   });
 });

--- a/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
+++ b/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { registerDeprecationHandler } from '@ember/debug';
+import { getOwner } from '@ember/application';
 import sinonjs from 'sinon';
 import InternalSession from 'ember-simple-auth/internal-session';
 import SessionService from 'ember-simple-auth/services/session';
@@ -58,7 +59,7 @@ module('setupSessionService', function (hooks) {
     this.owner.register(
       'service:session',
       class extends SessionService {
-        session = InternalSession.create(this);
+        session = new InternalSession(getOwner(this));
       }
     );
 

--- a/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
+++ b/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { registerDeprecationHandler } from '@ember/debug';
-import { getOwner } from '@ember/application';
 import sinonjs from 'sinon';
+import Configuration from 'ember-simple-auth/configuration';
 import InternalSession from 'ember-simple-auth/internal-session';
-import SessionService from 'ember-simple-auth/services/session';
+import setupSession from 'ember-simple-auth/initializers/setup-session';
 
 const SESSION_MAIN_DEPRECATION_ID = 'ember-simple-auth.session-main';
 
@@ -19,6 +19,17 @@ function collectDeprecations() {
   return deprecations;
 }
 
+function createRegistry() {
+  const registrations = {};
+
+  return {
+    registrations,
+    register(name, factory) {
+      registrations[name] = factory;
+    },
+  };
+}
+
 module('setupSessionService', function (hooks) {
   setupTest(hooks);
   let sinon;
@@ -28,10 +39,11 @@ module('setupSessionService', function (hooks) {
   });
 
   hooks.afterEach(function () {
+    Configuration.load({});
     sinon.restore();
   });
 
-  test('injects the session into the session service', function (assert) {
+  test('looks up session:main when useInternalSessionLookup is true', function (assert) {
     const deprecations = collectDeprecations();
 
     assert.equal(this.owner.lookup('service:session').session, this.owner.lookup('session:main'));
@@ -41,9 +53,17 @@ module('setupSessionService', function (hooks) {
     );
   });
 
-  test('creates InternalSession when session:main is not registered', function (assert) {
-    this.owner.unregister('session:main');
+  test('constructs InternalSession when useInternalSessionLookup is false', function (assert) {
+    Configuration.load({ useInternalSessionLookup: false });
     const deprecations = collectDeprecations();
+    const originalLookup = this.owner.lookup.bind(this.owner);
+    this.owner.lookup = (fullName, ...args) => {
+      if (fullName === 'session:main') {
+        return undefined;
+      }
+
+      return originalLookup(fullName, ...args);
+    };
 
     const service = this.owner.lookup('service:session');
 
@@ -54,18 +74,33 @@ module('setupSessionService', function (hooks) {
     );
   });
 
-  test('uses an InternalSession assigned on the session service', function (assert) {
-    this.owner.unregister('service:session');
-    this.owner.register(
-      'service:session',
-      class extends SessionService {
-        session = new InternalSession(getOwner(this));
+  test('does not register session:main when useInternalSessionLookup is false', function (assert) {
+    Configuration.load({ useInternalSessionLookup: false });
+    const registry = createRegistry();
+
+    setupSession(registry);
+
+    assert.notOk(registry.registrations['session:main']);
+  });
+
+  test('registers session:main when useInternalSessionLookup is true', function (assert) {
+    const registry = createRegistry();
+
+    setupSession(registry);
+
+    assert.ok(registry.registrations['session:main']);
+  });
+
+  test('asserts when useInternalSessionLookup is true and session:main is missing', function (assert) {
+    const originalLookup = this.owner.lookup.bind(this.owner);
+    this.owner.lookup = (fullName, ...args) => {
+      if (fullName === 'session:main') {
+        return undefined;
       }
-    );
 
-    const service = this.owner.lookup('service:session');
+      return originalLookup(fullName, ...args);
+    };
 
-    assert.ok(service.session instanceof InternalSession);
-    assert.notEqual(service.session, this.owner.lookup('session:main'));
+    assert.throws(() => this.owner.lookup('service:session'));
   });
 });

--- a/packages/test-esa/tests/unit/internal-session-store-test.js
+++ b/packages/test-esa/tests/unit/internal-session-store-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import sinonjs from 'sinon';
+import InternalSession from 'ember-simple-auth/internal-session';
 
 module('InternalSession store injection', function (hooks) {
   setupApplicationTest(hooks);
@@ -13,12 +14,20 @@ module('InternalSession store injection', function (hooks) {
   });
 
   hooks.afterEach(function () {
+    if (session && session !== this.owner.lookup('session:main')) {
+      session.destroy();
+    }
     sinon.restore();
   });
 
   module('session store injection', function () {
     test('looks up the test session store when isTesting()', function (assert) {
       session = this.owner.lookup('session:main');
+      assert.equal(session.get('store'), this.owner.lookup('session-store:test'));
+    });
+
+    test('looks up the test session store when created without the resolver', function (assert) {
+      session = InternalSession.create(this.owner);
       assert.equal(session.get('store'), this.owner.lookup('session-store:test'));
     });
   });

--- a/packages/test-esa/tests/unit/internal-session-store-test.js
+++ b/packages/test-esa/tests/unit/internal-session-store-test.js
@@ -27,7 +27,7 @@ module('InternalSession store injection', function (hooks) {
     });
 
     test('looks up the test session store when created without the resolver', function (assert) {
-      session = InternalSession.create(this.owner);
+      session = new InternalSession(this.owner);
       assert.equal(session.get('store'), this.owner.lookup('session-store:test'));
     });
   });

--- a/packages/test-esa/tests/unit/internal-session-test.js
+++ b/packages/test-esa/tests/unit/internal-session-test.js
@@ -1,8 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { next } from '@ember/runloop';
+import { get, set } from '@ember/object';
 import sinonjs from 'sinon';
 import Authenticator from 'ember-simple-auth/authenticators/base';
+import InternalSession from 'ember-simple-auth/internal-session';
 
 module('InternalSession', function (hooks) {
   setupTest(hooks);
@@ -17,11 +19,12 @@ module('InternalSession', function (hooks) {
 
     this.owner.register('authenticator:test', Authenticator);
     authenticator = this.owner.lookup('authenticator:test');
-    session = this.owner.lookup('session:main');
+    session = InternalSession.create(this.owner);
     store = session.get('store');
   });
 
   hooks.afterEach(function () {
+    session.destroy();
     sinon.restore();
   });
 
@@ -33,6 +36,13 @@ module('InternalSession', function (hooks) {
     } catch (e) {
       assert.ok(true);
     }
+  });
+
+  test('delegates unknown property reads and writes to its content', function (assert) {
+    set(session, 'some', 'data');
+
+    assert.equal(get(session, 'some'), 'data');
+    assert.equal(session.content.some, 'data');
   });
 
   function itHandlesAuthenticatorEvents(preparation) {

--- a/packages/test-esa/tests/unit/internal-session-test.js
+++ b/packages/test-esa/tests/unit/internal-session-test.js
@@ -19,7 +19,7 @@ module('InternalSession', function (hooks) {
 
     this.owner.register('authenticator:test', Authenticator);
     authenticator = this.owner.lookup('authenticator:test');
-    session = InternalSession.create(this.owner);
+    session = new InternalSession(this.owner);
     store = session.get('store');
   });
 

--- a/packages/test-esa/tests/unit/services/session-test.js
+++ b/packages/test-esa/tests/unit/services/session-test.js
@@ -94,11 +94,9 @@ module('SessionService', function (hooks) {
 
   module('authenticate', function (hooks) {
     hooks.beforeEach(function () {
-      session.reopen({
-        authenticate() {
-          return 'value';
-        },
-      });
+      session.authenticate = function () {
+        return 'value';
+      };
     });
 
     test('authenticates the session', function (assert) {
@@ -115,11 +113,9 @@ module('SessionService', function (hooks) {
 
   module('invalidate', function (hooks) {
     hooks.beforeEach(function () {
-      session.reopen({
-        invalidate() {
-          return 'value';
-        },
-      });
+      session.invalidate = function () {
+        return 'value';
+      };
     });
 
     test('invalidates the session', function (assert) {


### PR DESCRIPTION
- Refactors the InternalSession away from an ObjectProxy and into a native class `EmberObject`.
- Fixes incorrect `InternalSessionMock` typings

`useInternalSessionLookup` (default `true`) keeps the legacy `session:main` registered. 
Set `useInternalSessionLookup` it to `false` to opt into the new behavior, where the service constructs `InternalSession` and `session:main` is not registered so leftover `owner.lookup('session:main')` fail loudly.

 https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#resolver-registration

```js
  // config/environment.js
  ENV['ember-simple-auth'] = {
    useResolver: false,
  };
```

Related #3085 