### PR TITLE
feat: add `useResolver` flag. Allow session usage without Ember resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
           - ember-lts-6.4
           - ember-default
           - ember-release
+        include:
+          - FASTBOOT_DISABLED: 'true'
+            ember-version: ember-default
+            esa-use-resolver: 'false'
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -127,9 +131,10 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - run: pnpm install
-      - name: (FASTBOOT_DISABLED=${{ matrix.FASTBOOT_DISABLED }}) ${{ matrix.ember-version }}
+      - name: (FASTBOOT_DISABLED=${{ matrix.FASTBOOT_DISABLED }}) ${{ matrix.ember-version }}${{ matrix.esa-use-resolver == 'false' && ' useResolver=false' || '' }}
         env:
           FASTBOOT_DISABLED: ${{ matrix.FASTBOOT_DISABLED }}
+          PUBLIC_ESA_USE_RESOLVER: ${{ matrix.esa-use-resolver }}
           EMBER_SERVER_COMMAND: pnpm -F test-app test:one ${{ matrix.ember-version }} --- pnpm start
         run: pnpm -F playwright-tests test:e2e:chromium
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
           - workspace: test-app
             test-suite: "test:one embroider-safe"
             allow-failure: false
+          - workspace: test-app
+            test-suite: test:no-resolver
+            allow-failure: false
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -1,10 +1,10 @@
 ## tl;dr
 
-Existing apps keep working with `useResolver: true` (the default). v9 can drop resolver-based `session:main` and `session-store:*` wiring when you opt out.
+Existing apps keep working with `useResolver: true` (the default). v9 can drop resolver-based `session:main`, `session-store:*`, and `authenticator:*` wiring when you opt out.
 
 ## Resolver registration
 
-Set `useResolver` to `false`. The addon will no longer register `session:main`, `session-store:adaptive`, `session-store:cookie`, `session-store:local-storage`, or `session-store:test`, and will not look up `session-store:application`. Implement `createSessionStore` on the session service.
+Set `useResolver` to `false`. The addon will no longer register `session:main`, `session-store:adaptive`, `session-store:cookie`, `session-store:local-storage`, or `session-store:test`, and will not look up `session-store:application` or `authenticator:*`. Implement `createSessionStore` and `createAuthenticator` on the session service.
 
 ```js
 // config/environment.js
@@ -17,10 +17,17 @@ ENV['ember-simple-auth'] = {
 // app/services/session.js
 import SessionService from 'ember-simple-auth/services/session';
 import SessionStore from '../session-stores/application';
+import OAuth2 from '../authenticators/oauth2';
 
 export default class Session extends SessionService {
   createSessionStore(owner) {
     return new SessionStore(owner);
+  }
+
+  createAuthenticator(owner, name) {
+    if (name === 'authenticator:oauth2' || name === 'oauth2') {
+      return new OAuth2(owner);
+    }
   }
 }
 ```

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -4,7 +4,7 @@ Existing apps keep working with `useResolver: true` (the default). v9 can drop r
 
 ## Resolver registration
 
-Set `useResolver` to `false`. The addon will no longer register `session:main`, `session-store:adaptive`, `session-store:cookie`, `session-store:local-storage`, or `session-store:test`, and will not look up `session-store:application` or `authenticator:*`. Implement `createSessionStore` and `createAuthenticator` on the session service.
+Set `useResolver` to `false`. The addon will no longer register `session:main`, `session-store:adaptive`, `session-store:cookie`, `session-store:local-storage`, or `session-store:test`, and will not look up `session-store:application` or `authenticator:*`. Implement `createSessionStore` and `createAuthenticators` on the session service.
 
 ```js
 // config/environment.js
@@ -24,10 +24,10 @@ export default class Session extends SessionService {
     return new SessionStore(owner);
   }
 
-  createAuthenticator(owner, name) {
-    if (name === 'authenticator:oauth2' || name === 'oauth2') {
-      return new OAuth2(owner);
-    }
+  createAuthenticators(owner) {
+    return {
+      'authenticator:oauth2': new OAuth2(owner),
+    };
   }
 }
 ```

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -4,13 +4,22 @@ Existing apps keep working with `useResolver: true` (the default). v9 can drop r
 
 ## Resolver registration
 
-Set `useResolver` to `false`. The addon will no longer register `session:main`, `session-store:adaptive`, `session-store:cookie`, `session-store:local-storage`, or `session-store:test`, and will not look up `session-store:application` or `authenticator:*`. Implement `createSessionStore` and `createAuthenticators` on the session service.
+Set `useResolver` to `false`. The addon will no longer register `session:main`, `session-store:adaptive`, `session-store:cookie`, `session-store:local-storage`, or `session-store:test`, and will not look up `session-store:application`. Implement `createSessionStore` and `createAuthenticators` on the session service.
 
 ```js
 // config/environment.js
 ENV['ember-simple-auth'] = {
   useResolver: false,
 };
+```
+
+```js
+// app/authenticators/oauth2.js
+import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
+
+export default class OAuth2 extends OAuth2PasswordGrant {
+  static id = 'oauth2';
+}
 ```
 
 ```js
@@ -25,9 +34,11 @@ export default class Session extends SessionService {
   }
 
   createAuthenticators(owner) {
-    return {
-      'authenticator:oauth2': new OAuth2(owner),
-    };
+    return [new OAuth2(owner)];
   }
 }
 ```
+
+Each authenticator must have a static `id`.
+`authenticate` accepts class, instance, id, or factory name.
+Set `static id` to the old filename.

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -1,14 +1,26 @@
 ## tl;dr
 
-v9 removes resolver-based `session:main` wiring. The session service owns `InternalSession` directly.
+Existing apps keep working with `useResolver: true` (the default). v9 can drop resolver-based `session:main` and `session-store:*` wiring when you opt out.
 
-## `session:main` resolver registration
+## Resolver registration
 
-Set `useInternalSessionLookup` to `false` so the session service constructs `InternalSession` and `session:main` is not registered.
+Set `useResolver` to `false`. The addon will no longer register `session:main`, `session-store:adaptive`, `session-store:cookie`, `session-store:local-storage`, or `session-store:test`, and will not look up `session-store:application`. Implement `createSessionStore` on the session service.
 
 ```js
 // config/environment.js
 ENV['ember-simple-auth'] = {
-  useInternalSessionLookup: false,
+  useResolver: false,
 };
+```
+
+```js
+// app/services/session.js
+import SessionService from 'ember-simple-auth/services/session';
+import SessionStore from '../session-stores/application';
+
+export default class Session extends SessionService {
+  createSessionStore(owner) {
+    return new SessionStore(owner);
+  }
+}
 ```

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -76,11 +76,6 @@ export default class SessionStore extends AdaptiveStore {
 }
 ```
 
-## Property assignment
-
-Use regular assignment to update custom properties; `Ember.set` and `.set()` also work with tracked fields.
-Declare custom state consumed by templates or reactive getters with `@tracked`.
-
 ## Complete session service
 
 With `useResolver: false` configured above, this service combines a typed cookie store with the OAuth2 authenticator from the earlier example.

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -1,25 +1,13 @@
-## tl;dr
-
-Existing apps keep working with `useResolver: true` (the default). v9 can drop resolver-based `session:main`, `session-store:*`, and `authenticator:*` wiring when you opt out.
-
 ## Resolver registration
 
-Set `useResolver` to `false`. The addon will no longer register `session:main`, `session-store:adaptive`, `session-store:cookie`, `session-store:local-storage`, or `session-store:test`, and will not look up `session-store:application`. Implement `createSessionStore` and `createAuthenticators` on the session service.
+Existing apps keep resolver registration and `init` hooks with `useResolver: true` (the default).
+To opt out, set `useResolver: false` and implement `createSessionStore` and `createAuthenticators`:
 
 ```js
 // config/environment.js
 ENV['ember-simple-auth'] = {
   useResolver: false,
 };
-```
-
-```js
-// app/authenticators/oauth2.js
-import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
-
-export default class OAuth2 extends OAuth2PasswordGrant {
-  static id = 'oauth2';
-}
 ```
 
 ```js
@@ -39,6 +27,79 @@ export default class Session extends SessionService {
 }
 ```
 
-Each authenticator must have a static `id`.
-`authenticate` accepts class, instance, id, or factory name.
-Set `static id` to the old filename.
+## Authenticator IDs
+
+With `useResolver: false`, each authenticator needs a static `id` matching its previous filename to preserve stored sessions.
+`authenticate` accepts a class, instance, ID, or factory name.
+
+```js
+// app/authenticators/oauth2.js
+import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
+
+export default class OAuth2 extends OAuth2PasswordGrant {
+  static id = 'oauth2';
+}
+```
+
+## Store types
+
+Use the optional second `SessionService` type parameter to type `session.store` and `createSessionStore`, keeping your session data type first.
+Existing `SessionService<Data>` subclasses and `declare store: CustomStore` declarations remain supported.
+
+```ts
+import type Owner from '@ember/owner';
+import SessionService, { type DefaultDataShape } from 'ember-simple-auth/services/session';
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+
+export default class Session extends SessionService<DefaultDataShape, CookieStore> {
+  createSessionStore(owner: Owner) {
+    return new CookieStore(owner);
+  }
+
+  // Keep createAuthenticators from the example above.
+}
+```
+
+## Initialization
+
+With `useResolver: false`, stores and authenticators are created with `new`, which skips `init`.
+Move your old `init` code into a constructor after `super(owner)`:
+
+```js
+import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
+
+export default class SessionStore extends AdaptiveStore {
+  constructor(owner) {
+    super(owner);
+    // Your own setup code
+  }
+}
+```
+
+## Complete session service
+
+With `useResolver: false` configured above, this service combines a typed cookie store with the OAuth2 authenticator from the earlier example.
+
+```ts
+// app/services/session.ts
+import type Owner from '@ember/owner';
+import SessionService, { type DefaultDataShape } from 'ember-simple-auth/services/session';
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+import OAuth2 from '../authenticators/oauth2';
+
+export default class Session extends SessionService<DefaultDataShape, CookieStore> {
+  createSessionStore(owner: Owner) {
+    return new CookieStore(owner);
+  }
+
+  createAuthenticators(owner: Owner) {
+    return [new OAuth2(owner)];
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    session: Session;
+  }
+}
+```

--- a/guides/upgrade-to-v9.md
+++ b/guides/upgrade-to-v9.md
@@ -76,6 +76,11 @@ export default class SessionStore extends AdaptiveStore {
 }
 ```
 
+## Property assignment
+
+Use regular assignment to update custom properties; `Ember.set` and `.set()` also work with tracked fields.
+Declare custom state consumed by templates or reactive getters with `@tracked`.
+
 ## Complete session service
 
 With `useResolver: false` configured above, this service combines a typed cookie store with the OAuth2 authenticator from the earlier example.

--- a/packages/ember-simple-auth/src/authenticators/devise.ts
+++ b/packages/ember-simple-auth/src/authenticators/devise.ts
@@ -20,6 +20,8 @@ export type NestedRecord = Record<string, string | Record<string, string>>;
   @public
 */
 export default class DeviseAuthenticator extends BaseAuthenticator {
+  static id = 'devise';
+
   /**
     The endpoint on the server that the authentication request is sent to.
 

--- a/packages/ember-simple-auth/src/authenticators/oauth2-implicit-grant.ts
+++ b/packages/ember-simple-auth/src/authenticators/oauth2-implicit-grant.ts
@@ -55,6 +55,8 @@ export type ImplicitGrantData = {
  @public
  */
 export default class OAuth2ImplicitGrantAuthenticator extends BaseAuthenticator {
+  static id = 'oauth2-implicit-grant';
+
   /**
    Restores the session from a session data object; __will return a resolving
    promise when there is a non-empty `access_token` in the session data__ and

--- a/packages/ember-simple-auth/src/authenticators/oauth2-password-grant.ts
+++ b/packages/ember-simple-auth/src/authenticators/oauth2-password-grant.ts
@@ -63,6 +63,8 @@ export interface OAuth2Response extends Response {
   @public
 */
 export default class OAuth2PasswordGrantAuthenticator extends BaseAuthenticator {
+  static id = 'oauth2-password-grant';
+
   /**
     Triggered when the authenticator refreshed the access token (see
     [RFC 6749, section 6](http://tools.ietf.org/html/rfc6749#section-6)).

--- a/packages/ember-simple-auth/src/authenticators/test.ts
+++ b/packages/ember-simple-auth/src/authenticators/test.ts
@@ -1,6 +1,8 @@
 import BaseAuthenticator from './base';
 
 export default class TestAuthenticator extends BaseAuthenticator {
+  static id = 'test';
+
   restore(data: any) {
     return Promise.resolve(data);
   }

--- a/packages/ember-simple-auth/src/authenticators/torii.js
+++ b/packages/ember-simple-auth/src/authenticators/torii.js
@@ -36,6 +36,7 @@ deprecate('Ember Simple Auth: The Torii authenticator is deprecated.', false, {
   @public
 */
 export default class ToriiAuthenticator extends BaseAuthenticator {
+  static id = 'torii';
   _provider = null;
 
   /**

--- a/packages/ember-simple-auth/src/configuration.js
+++ b/packages/ember-simple-auth/src/configuration.js
@@ -38,9 +38,10 @@ export default {
   routeAfterAuthentication: DEFAULTS.routeAfterAuthentication,
 
   /**
-    When `true`, the session service looks up `session:main` and session stores
-    from the resolver. When `false`, it constructs `InternalSession` and the
-    store via `createSessionStore`.
+    When `true`, the session service looks up `session:main`, session stores,
+    and authenticators from the resolver. When `false`, it constructs
+    `InternalSession` and the store via `createSessionStore`, and authenticators
+    via `createAuthenticator`.
 
     @memberof Configuration
     @property useResolver

--- a/packages/ember-simple-auth/src/configuration.js
+++ b/packages/ember-simple-auth/src/configuration.js
@@ -1,7 +1,7 @@
 const DEFAULTS = {
   rootURL: '',
   routeAfterAuthentication: 'index',
-  useInternalSessionLookup: true,
+  useResolver: true,
 };
 
 /**
@@ -38,17 +38,18 @@ export default {
   routeAfterAuthentication: DEFAULTS.routeAfterAuthentication,
 
   /**
-    When `true`, the session service looks up `session:main` from the resolver.
-    When `false`, the session service constructs `InternalSession` itself.
+    When `true`, the session service looks up `session:main` and session stores
+    from the resolver. When `false`, it constructs `InternalSession` and the
+    store via `createSessionStore`.
 
     @memberof Configuration
-    @property useInternalSessionLookup
+    @property useResolver
     @static
     @type Boolean
     @default true
     @public
   */
-  useInternalSessionLookup: DEFAULTS.useInternalSessionLookup,
+  useResolver: DEFAULTS.useResolver,
 
   load(config) {
     this.rootURL = config.rootURL !== undefined ? config.rootURL : DEFAULTS.rootURL;
@@ -56,9 +57,6 @@ export default {
       config.routeAfterAuthentication !== undefined
         ? config.routeAfterAuthentication
         : DEFAULTS.routeAfterAuthentication;
-    this.useInternalSessionLookup =
-      config.useInternalSessionLookup !== undefined
-        ? config.useInternalSessionLookup
-        : DEFAULTS.useInternalSessionLookup;
+    this.useResolver = config.useResolver !== undefined ? config.useResolver : DEFAULTS.useResolver;
   },
 };

--- a/packages/ember-simple-auth/src/configuration.js
+++ b/packages/ember-simple-auth/src/configuration.js
@@ -41,7 +41,7 @@ export default {
     When `true`, the session service looks up `session:main`, session stores,
     and authenticators from the resolver. When `false`, it constructs
     `InternalSession` and the store via `createSessionStore`, and authenticators
-    via `createAuthenticator`.
+    via `createAuthenticators`.
 
     @memberof Configuration
     @property useResolver

--- a/packages/ember-simple-auth/src/initializers/ember-simple-auth.js
+++ b/packages/ember-simple-auth/src/initializers/ember-simple-auth.js
@@ -13,9 +13,11 @@ export default {
     config.rootURL = ENV.rootURL || ENV.baseURL;
     Configuration.load(config);
 
-    registry.register('session-store:adaptive', Adaptive);
-    registry.register('session-store:cookie', Cookie);
-    registry.register('session-store:local-storage', LocalStorage);
+    if (Configuration.useResolver) {
+      registry.register('session-store:adaptive', Adaptive);
+      registry.register('session-store:cookie', Cookie);
+      registry.register('session-store:local-storage', LocalStorage);
+    }
 
     setupSession(registry);
   },

--- a/packages/ember-simple-auth/src/initializers/setup-session.js
+++ b/packages/ember-simple-auth/src/initializers/setup-session.js
@@ -4,11 +4,11 @@ import { isTesting } from '@embroider/macros';
 import Configuration from '../configuration';
 
 export default function setupSession(registry) {
-  if (Configuration.useInternalSessionLookup) {
+  if (Configuration.useResolver) {
     registry.register('session:main', InternalSession);
-  }
 
-  if (isTesting()) {
-    registry.register('session-store:test', Ephemeral);
+    if (isTesting()) {
+      registry.register('session-store:test', Ephemeral);
+    }
   }
 }

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -4,11 +4,51 @@ import { debug, assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import { associateDestroyableChild } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
-import { isTesting } from '@embroider/macros';
+import { isTesting, isDevelopingApp, macroCondition } from '@embroider/macros';
 import Configuration from './configuration';
 import EsaEventTarget from './-internals/event-target';
 
 class SessionEventTarget extends EsaEventTarget {}
+
+const authenticatorMatches = (authenticator, authenticatorRef) => {
+  if (authenticator === authenticatorRef) {
+    return true;
+  } else if (typeof authenticatorRef === 'function') {
+    return (
+      authenticator.constructor === authenticatorRef || authenticator instanceof authenticatorRef
+    );
+  } else if (typeof authenticatorRef === 'string') {
+    const id = authenticator.constructor.id;
+    return id === authenticatorRef || `authenticator:${id}` === authenticatorRef;
+  } else {
+    return false;
+  }
+};
+
+const assertAuthenticators = authenticators => {
+  if (!authenticators) {
+    return;
+  }
+
+  assert(
+    'Ember Simple Auth: createAuthenticators must return an array of authenticator instances.',
+    Array.isArray(authenticators)
+  );
+
+  const seen = new Set();
+  authenticators.forEach(authenticator => {
+    const id = authenticator?.constructor?.id;
+    assert(
+      'Ember Simple Auth: each authenticator returned from createAuthenticators must have a static id.',
+      !isEmpty(id)
+    );
+    assert(
+      `Ember Simple Auth: duplicate authenticator id "${id}" returned from createAuthenticators.`,
+      !seen.has(id)
+    );
+    seen.add(id);
+  });
+};
 
 /**
   __An internal implementation of Session. Communicates with stores and emits events.__
@@ -61,12 +101,20 @@ export default class InternalSession extends EmberObject {
     this.sessionEvents = new SessionEventTarget();
     this._busy = false;
     this._authenticators = options.authenticators || null;
+    if (macroCondition(isDevelopingApp())) {
+      assertAuthenticators(this._authenticators);
+    }
 
     const store = sessionStore || this._lookupStore();
     assert('Ember Simple Auth: InternalSession requires a session store.', store);
     this.store = store;
     if (sessionStore) {
       associateDestroyableChild(this, sessionStore);
+    }
+    if (this._authenticators) {
+      this._authenticators.forEach(authenticator => {
+        associateDestroyableChild(this, authenticator);
+      });
     }
     this._bindToStoreEvents();
   }
@@ -84,9 +132,9 @@ export default class InternalSession extends EmberObject {
     this._busy = true;
     assert(
       `Session#authenticate requires the authenticator to be specified, was "${authenticatorFactory}"!`,
-      !isEmpty(authenticatorFactory)
+      authenticatorFactory != null && authenticatorFactory !== ''
     );
-    const authenticator = this._lookupAuthenticator(authenticatorFactory);
+    const authenticator = this._findAuthenticator(authenticatorFactory);
 
     return authenticator.authenticate(...args).then(
       content => {
@@ -111,7 +159,7 @@ export default class InternalSession extends EmberObject {
       return Promise.resolve();
     }
 
-    let authenticator = this._lookupAuthenticator(this.authenticator);
+    let authenticator = this._findAuthenticator(this.authenticator);
     return authenticator.invalidate(this.content.authenticated, ...arguments).then(
       () => {
         authenticator.off('sessionDataUpdated', this._onSessionDataUpdated);
@@ -135,7 +183,7 @@ export default class InternalSession extends EmberObject {
         let { authenticator: authenticatorFactory } = restoredContent.authenticated || {};
         if (authenticatorFactory) {
           delete restoredContent.authenticated.authenticator;
-          const authenticator = this._lookupAuthenticator(authenticatorFactory);
+          const authenticator = this._findAuthenticator(authenticatorFactory);
           return authenticator.restore(restoredContent.authenticated).then(
             content => {
               this.content = restoredContent;
@@ -179,7 +227,10 @@ export default class InternalSession extends EmberObject {
   _setup(authenticator, authenticatedContent, trigger) {
     trigger = Boolean(trigger) && !this.get('isAuthenticated');
     this.isAuthenticated = true;
-    this.authenticator = authenticator;
+    this.authenticator =
+      typeof authenticator === 'string'
+        ? authenticator
+        : this._findAuthenticator(authenticator).constructor.id;
     this._withAuthenticated(authenticatedContent);
     this._bindToAuthenticatorEvents();
 
@@ -248,7 +299,7 @@ export default class InternalSession extends EmberObject {
   }
 
   _bindToAuthenticatorEvents() {
-    const authenticator = this._lookupAuthenticator(this.authenticator);
+    const authenticator = this._findAuthenticator(this.authenticator);
     authenticator.on('sessionDataUpdated', this._onSessionDataUpdated);
     authenticator.on('sessionDataInvalidated', this._onSessionDataInvalidated);
   }
@@ -270,7 +321,7 @@ export default class InternalSession extends EmberObject {
         let { authenticator: authenticatorFactory } = content.authenticated || {};
         if (authenticatorFactory) {
           delete content.authenticated.authenticator;
-          const authenticator = this._lookupAuthenticator(authenticatorFactory);
+          const authenticator = this._findAuthenticator(authenticatorFactory);
           authenticator.restore(content.authenticated).then(
             authenticatedContent => {
               this._replaceContent(content);
@@ -296,29 +347,41 @@ export default class InternalSession extends EmberObject {
     });
   }
 
-  _lookupAuthenticator(authenticatorName) {
-    let owner = getOwner(this);
-
+  _findAuthenticator(authenticatorRef) {
     if (this._authenticators) {
-      let authenticator = this._authenticators[authenticatorName];
-      assert(
-        `No matching authenticator was returned from 'SessionService.createAuthenticators': "${authenticatorName}" could be found!`,
-        !isNone(authenticator)
+      const matches = this._authenticators.filter(authenticator =>
+        authenticatorMatches(authenticator, authenticatorRef)
       );
-      return authenticator;
+
+      if (typeof authenticatorRef === 'function') {
+        assert(
+          `Multiple authenticators returned from 'SessionService.createAuthenticators' matched factory "${
+            authenticatorRef.name || authenticatorRef
+          }".`,
+          matches.length <= 1
+        );
+      }
+
+      if (matches[0]) {
+        return matches[0];
+      }
+    }
+
+    if (typeof authenticatorRef === 'string' && authenticatorRef.includes(':')) {
+      const fromRegistry = getOwner(this).lookup(authenticatorRef);
+      if (!isNone(fromRegistry)) {
+        return fromRegistry;
+      }
     }
 
     assert(
       'Ember Simple Auth: InternalSession requires createAuthenticators when useResolver is false.',
-      Configuration.useResolver
+      Boolean(this._authenticators) || Configuration.useResolver
     );
-
-    let authenticator = owner.lookup(authenticatorName);
     assert(
-      `No authenticator for factory "${authenticatorName}" could be found!`,
-      !isNone(authenticator)
+      `No authenticator for factory "${authenticatorRef}" could be found!`,
+      false
     );
-    return authenticator;
   }
 
   on(event, cb) {

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -1,7 +1,7 @@
 import { isEmpty, isNone } from '@ember/utils';
 import EmberObject, { action, get, set } from '@ember/object';
 import { debug, assert } from '@ember/debug';
-import { getOwner, setOwner } from '@ember/application';
+import { getOwner } from '@ember/application';
 import { associateDestroyableChild } from '@ember/destroyable';
 import { isTesting } from '@embroider/macros';
 import Configuration from './configuration';
@@ -59,8 +59,7 @@ export default class InternalSession extends EmberObject {
     this.set('content', { authenticated: {} });
     this.sessionEvents = new SessionEventTarget();
     this._busy = false;
-    this._createAuthenticator = options.createAuthenticator;
-    this._authenticators = this._createAuthenticator ? {} : null;
+    this._authenticators = options.authenticators || null;
 
     const store = sessionStore || this._lookupStore();
     assert('Ember Simple Auth: InternalSession requires a session store.', store);
@@ -296,23 +295,17 @@ export default class InternalSession extends EmberObject {
   _lookupAuthenticator(authenticatorName) {
     let owner = getOwner(this);
 
-    if (this._createAuthenticator) {
+    if (this._authenticators) {
       let authenticator = this._authenticators[authenticatorName];
-      if (!authenticator) {
-        authenticator = this._createAuthenticator(authenticatorName);
-        assert(
-          `No authenticator for factory "${authenticatorName}" could be found!`,
-          !isNone(authenticator)
-        );
-        setOwner(authenticator, owner);
-        associateDestroyableChild(this, authenticator);
-        this._authenticators[authenticatorName] = authenticator;
-      }
+      assert(
+        `No matching authenticator was returned from 'SessionService.createAuthenticators': "${authenticatorName}" could be found!`,
+        !isNone(authenticator)
+      );
       return authenticator;
     }
 
     assert(
-      'Ember Simple Auth: InternalSession requires createAuthenticator when useResolver is false.',
+      'Ember Simple Auth: InternalSession requires createAuthenticators when useResolver is false.',
       Configuration.useResolver
     );
 
@@ -321,7 +314,6 @@ export default class InternalSession extends EmberObject {
       `No authenticator for factory "${authenticatorName}" could be found!`,
       !isNone(authenticator)
     );
-    setOwner(authenticator, owner);
     return authenticator;
   }
 

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -1,8 +1,9 @@
 import { isEmpty, isNone } from '@ember/utils';
-import EmberObject, { action, get, set } from '@ember/object';
+import EmberObject, { action, get } from '@ember/object';
 import { debug, assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import { associateDestroyableChild } from '@ember/destroyable';
+import { tracked } from '@glimmer/tracking';
 import { isTesting } from '@embroider/macros';
 import Configuration from './configuration';
 import EsaEventTarget from './-internals/event-target';
@@ -46,24 +47,24 @@ export default class InternalSession extends EmberObject {
     @private
   */
   authenticator = null;
-  content = { authenticated: {} };
-  store = null;
-  isAuthenticated = false;
-  attemptedTransition = null;
+  @tracked content = { authenticated: {} };
+  @tracked store = null;
+  @tracked isAuthenticated = false;
+  @tracked attemptedTransition = null;
   sessionEvents = null;
   redirectTarget = null;
 
   constructor(owner, sessionStore, options = {}) {
     super(owner);
 
-    this.set('content', { authenticated: {} });
+    this.content = { authenticated: {} };
     this.sessionEvents = new SessionEventTarget();
     this._busy = false;
     this._authenticators = options.authenticators || null;
 
     const store = sessionStore || this._lookupStore();
     assert('Ember Simple Auth: InternalSession requires a session store.', store);
-    this.set('store', store);
+    this.store = store;
     if (sessionStore) {
       associateDestroyableChild(this, sessionStore);
     }
@@ -103,7 +104,7 @@ export default class InternalSession extends EmberObject {
 
   invalidate() {
     this._busy = true;
-    this.set('attemptedTransition', null);
+    this.attemptedTransition = null;
 
     if (!this.get('isAuthenticated')) {
       this._busy = false;
@@ -137,7 +138,7 @@ export default class InternalSession extends EmberObject {
           const authenticator = this._lookupAuthenticator(authenticatorFactory);
           return authenticator.restore(restoredContent.authenticated).then(
             content => {
-              this.set('content', restoredContent);
+              this.content = restoredContent;
               this._busy = false;
               return this._setup(authenticatorFactory, content);
             },
@@ -165,13 +166,21 @@ export default class InternalSession extends EmberObject {
     );
   }
 
+  _replaceContent(next) {
+    this.content = next;
+  }
+
+  _withAuthenticated(authenticatedContent) {
+    this._replaceContent(
+      Object.assign({}, this.content || {}, { authenticated: authenticatedContent })
+    );
+  }
+
   _setup(authenticator, authenticatedContent, trigger) {
     trigger = Boolean(trigger) && !this.get('isAuthenticated');
-    this.setProperties({
-      isAuthenticated: true,
-      authenticator,
-      'content.authenticated': authenticatedContent,
-    });
+    this.isAuthenticated = true;
+    this.authenticator = authenticator;
+    this._withAuthenticated(authenticatedContent);
     this._bindToAuthenticatorEvents();
 
     return this._updateStore().then(
@@ -181,22 +190,18 @@ export default class InternalSession extends EmberObject {
         }
       },
       () => {
-        this.setProperties({
-          isAuthenticated: false,
-          authenticator: null,
-          'content.authenticated': {},
-        });
+        this.isAuthenticated = false;
+        this.authenticator = null;
+        this._withAuthenticated({});
       }
     );
   }
 
   _clear(trigger) {
     trigger = Boolean(trigger) && this.get('isAuthenticated');
-    this.setProperties({
-      isAuthenticated: false,
-      authenticator: null,
-      'content.authenticated': {},
-    });
+    this.isAuthenticated = false;
+    this.authenticator = null;
+    this._withAuthenticated({});
 
     return this._updateStore().then(() => {
       if (trigger) {
@@ -206,7 +211,7 @@ export default class InternalSession extends EmberObject {
   }
 
   _clearWithContent(content, trigger) {
-    this.set('content', content);
+    this._replaceContent(content);
     return this._clear(trigger);
   }
 
@@ -223,22 +228,21 @@ export default class InternalSession extends EmberObject {
       `Cannot delegate set('${key}', ${value}) to the 'content' property of the internal session: its 'content' is undefined.`,
       content
     );
-    let result = set(content, key, value);
+    this._replaceContent(Object.assign({}, content, { [key]: value }));
     this.notifyPropertyChange(key);
     if (!/^_/.test(key)) {
       this._updateStore();
     }
-    return result;
+    return value;
   }
 
   _updateStore() {
     let data = this.content;
     if (!isEmpty(this.authenticator)) {
-      set(
-        data,
-        'authenticated',
-        Object.assign({ authenticator: this.authenticator }, data.authenticated || {})
-      );
+      data = Object.assign({}, data, {
+        authenticated: Object.assign({ authenticator: this.authenticator }, data.authenticated || {}),
+      });
+      this._replaceContent(data);
     }
     return this.store.persist(data);
   }
@@ -269,7 +273,7 @@ export default class InternalSession extends EmberObject {
           const authenticator = this._lookupAuthenticator(authenticatorFactory);
           authenticator.restore(content.authenticated).then(
             authenticatedContent => {
-              this.set('content', content);
+              this._replaceContent(content);
               this._busy = false;
               this._setup(authenticatorFactory, authenticatedContent, true);
             },

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -2,7 +2,9 @@ import { isEmpty, isNone } from '@ember/utils';
 import EmberObject, { action, get, set } from '@ember/object';
 import { debug, assert } from '@ember/debug';
 import { getOwner, setOwner } from '@ember/application';
+import { associateDestroyableChild } from '@ember/destroyable';
 import { isTesting } from '@embroider/macros';
+import Configuration from './configuration';
 import EsaEventTarget from './-internals/event-target';
 
 class SessionEventTarget extends EsaEventTarget {}
@@ -51,19 +53,29 @@ export default class InternalSession extends EmberObject {
   sessionEvents = null;
   redirectTarget = null;
 
-  constructor(owner) {
+  constructor(owner, sessionStore) {
     super(owner);
 
     this.set('content', { authenticated: {} });
-    let storeFactory = 'session-store:application';
-    if (isTesting()) {
-      storeFactory = 'session-store:test';
+    this.sessionEvents = new SessionEventTarget();
+    this._busy = false;
+
+    const store = sessionStore || this._lookupStore();
+    assert('Ember Simple Auth: InternalSession requires a session store.', store);
+    this.set('store', store);
+    if (sessionStore) {
+      associateDestroyableChild(this, sessionStore);
+    }
+    this._bindToStoreEvents();
+  }
+
+  _lookupStore() {
+    if (!Configuration.useResolver) {
+      return null;
     }
 
-    this.sessionEvents = new SessionEventTarget();
-    this.set('store', getOwner(this).lookup(storeFactory));
-    this._busy = false;
-    this._bindToStoreEvents();
+    let storeFactory = isTesting() ? 'session-store:test' : 'session-store:application';
+    return getOwner(this).lookup(storeFactory);
   }
 
   authenticate(authenticatorFactory, ...args) {

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -53,12 +53,14 @@ export default class InternalSession extends EmberObject {
   sessionEvents = null;
   redirectTarget = null;
 
-  constructor(owner, sessionStore) {
+  constructor(owner, sessionStore, options = {}) {
     super(owner);
 
     this.set('content', { authenticated: {} });
     this.sessionEvents = new SessionEventTarget();
     this._busy = false;
+    this._createAuthenticator = options.createAuthenticator;
+    this._authenticators = this._createAuthenticator ? {} : null;
 
     const store = sessionStore || this._lookupStore();
     assert('Ember Simple Auth: InternalSession requires a session store.', store);
@@ -293,6 +295,27 @@ export default class InternalSession extends EmberObject {
 
   _lookupAuthenticator(authenticatorName) {
     let owner = getOwner(this);
+
+    if (this._createAuthenticator) {
+      let authenticator = this._authenticators[authenticatorName];
+      if (!authenticator) {
+        authenticator = this._createAuthenticator(authenticatorName);
+        assert(
+          `No authenticator for factory "${authenticatorName}" could be found!`,
+          !isNone(authenticator)
+        );
+        setOwner(authenticator, owner);
+        associateDestroyableChild(this, authenticator);
+        this._authenticators[authenticatorName] = authenticator;
+      }
+      return authenticator;
+    }
+
+    assert(
+      'Ember Simple Auth: InternalSession requires createAuthenticator when useResolver is false.',
+      Configuration.useResolver
+    );
+
     let authenticator = owner.lookup(authenticatorName);
     assert(
       `No authenticator for factory "${authenticatorName}" could be found!`,

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -35,12 +35,8 @@ const assertAuthenticators = authenticators => {
   authenticators.forEach(authenticator => {
     const id = authenticator?.constructor?.id;
     assert(
-      'Ember Simple Auth: each authenticator returned from createAuthenticators must have a static string id.',
-      typeof id === 'string' && !isEmpty(id)
-    );
-    assert(
-      `Ember Simple Auth: duplicate authenticator id "${id}" returned from createAuthenticators.`,
-      !seen.has(id)
+      'Ember Simple Auth: each authenticator returned from createAuthenticators must have a unique, non-empty static string id.',
+      typeof id === 'string' && !isEmpty(id) && !seen.has(id)
     );
     seen.add(id);
   });
@@ -275,11 +271,10 @@ export default class InternalSession extends EmberObject {
   }
 
   setUnknownProperty(key, value) {
-    assert('"authenticated" is a reserved key used by Ember Simple Auth!', key !== 'authenticated');
     let content = get(this, 'content');
     assert(
-      `Cannot delegate set('${key}', ${value}) to the 'content' property of the internal session: its 'content' is undefined.`,
-      content
+      `Cannot delegate set('${key}', ${value}) to the internal session: 'content' must be defined and "authenticated" is a reserved key used by Ember Simple Auth.`,
+      key !== 'authenticated' && content
     );
     let result = set(content, key, value);
     this.notifyPropertyChange(key);

--- a/packages/ember-simple-auth/src/internal-session.js
+++ b/packages/ember-simple-auth/src/internal-session.js
@@ -1,7 +1,7 @@
 import { isEmpty, isNone } from '@ember/utils';
-import EmberObject, { action, get } from '@ember/object';
+import EmberObject, { action, get, set } from '@ember/object';
 import { debug, assert } from '@ember/debug';
-import { getOwner } from '@ember/application';
+import { getOwner, setOwner } from '@ember/application';
 import { associateDestroyableChild } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
 import { isTesting, isDevelopingApp, macroCondition } from '@embroider/macros';
@@ -26,10 +26,6 @@ const authenticatorMatches = (authenticator, authenticatorRef) => {
 };
 
 const assertAuthenticators = authenticators => {
-  if (!authenticators) {
-    return;
-  }
-
   assert(
     'Ember Simple Auth: createAuthenticators must return an array of authenticator instances.',
     Array.isArray(authenticators)
@@ -39,8 +35,8 @@ const assertAuthenticators = authenticators => {
   authenticators.forEach(authenticator => {
     const id = authenticator?.constructor?.id;
     assert(
-      'Ember Simple Auth: each authenticator returned from createAuthenticators must have a static id.',
-      !isEmpty(id)
+      'Ember Simple Auth: each authenticator returned from createAuthenticators must have a static string id.',
+      typeof id === 'string' && !isEmpty(id)
     );
     assert(
       `Ember Simple Auth: duplicate authenticator id "${id}" returned from createAuthenticators.`,
@@ -97,13 +93,10 @@ export default class InternalSession extends EmberObject {
   constructor(owner, sessionStore, options = {}) {
     super(owner);
 
-    this.content = { authenticated: {} };
     this.sessionEvents = new SessionEventTarget();
     this._busy = false;
-    this._authenticators = options.authenticators || null;
-    if (macroCondition(isDevelopingApp())) {
-      assertAuthenticators(this._authenticators);
-    }
+    this._authenticators = null;
+    this._setAuthenticators(options.authenticators);
 
     const store = sessionStore || this._lookupStore();
     assert('Ember Simple Auth: InternalSession requires a session store.', store);
@@ -111,12 +104,25 @@ export default class InternalSession extends EmberObject {
     if (sessionStore) {
       associateDestroyableChild(this, sessionStore);
     }
-    if (this._authenticators) {
-      this._authenticators.forEach(authenticator => {
-        associateDestroyableChild(this, authenticator);
-      });
-    }
     this._bindToStoreEvents();
+  }
+
+  _setAuthenticators(authenticators) {
+    if (!authenticators) {
+      return;
+    }
+
+    if (macroCondition(isDevelopingApp())) {
+      assertAuthenticators(authenticators);
+    }
+
+    const currentAuthenticators = new Set(this._authenticators || []);
+    this._authenticators = authenticators;
+    authenticators.forEach(authenticator => {
+      if (!currentAuthenticators.has(authenticator)) {
+        associateDestroyableChild(this, authenticator);
+      }
+    });
   }
 
   _lookupStore() {
@@ -152,7 +158,7 @@ export default class InternalSession extends EmberObject {
 
   invalidate() {
     this._busy = true;
-    this.attemptedTransition = null;
+    this.set('attemptedTransition', null);
 
     if (!this.get('isAuthenticated')) {
       this._busy = false;
@@ -186,7 +192,7 @@ export default class InternalSession extends EmberObject {
           const authenticator = this._findAuthenticator(authenticatorFactory);
           return authenticator.restore(restoredContent.authenticated).then(
             content => {
-              this.content = restoredContent;
+              this.set('content', restoredContent);
               this._busy = false;
               return this._setup(authenticatorFactory, content);
             },
@@ -214,24 +220,16 @@ export default class InternalSession extends EmberObject {
     );
   }
 
-  _replaceContent(next) {
-    this.content = next;
-  }
-
-  _withAuthenticated(authenticatedContent) {
-    this._replaceContent(
-      Object.assign({}, this.content || {}, { authenticated: authenticatedContent })
-    );
-  }
-
   _setup(authenticator, authenticatedContent, trigger) {
     trigger = Boolean(trigger) && !this.get('isAuthenticated');
-    this.isAuthenticated = true;
-    this.authenticator =
-      typeof authenticator === 'string'
-        ? authenticator
-        : this._findAuthenticator(authenticator).constructor.id;
-    this._withAuthenticated(authenticatedContent);
+    this.setProperties({
+      isAuthenticated: true,
+      authenticator:
+        typeof authenticator === 'string'
+          ? authenticator
+          : this._findAuthenticator(authenticator).constructor.id,
+      'content.authenticated': authenticatedContent,
+    });
     this._bindToAuthenticatorEvents();
 
     return this._updateStore().then(
@@ -241,18 +239,22 @@ export default class InternalSession extends EmberObject {
         }
       },
       () => {
-        this.isAuthenticated = false;
-        this.authenticator = null;
-        this._withAuthenticated({});
+        this.setProperties({
+          isAuthenticated: false,
+          authenticator: null,
+          'content.authenticated': {},
+        });
       }
     );
   }
 
   _clear(trigger) {
     trigger = Boolean(trigger) && this.get('isAuthenticated');
-    this.isAuthenticated = false;
-    this.authenticator = null;
-    this._withAuthenticated({});
+    this.setProperties({
+      isAuthenticated: false,
+      authenticator: null,
+      'content.authenticated': {},
+    });
 
     return this._updateStore().then(() => {
       if (trigger) {
@@ -262,7 +264,7 @@ export default class InternalSession extends EmberObject {
   }
 
   _clearWithContent(content, trigger) {
-    this._replaceContent(content);
+    this.set('content', content);
     return this._clear(trigger);
   }
 
@@ -279,21 +281,22 @@ export default class InternalSession extends EmberObject {
       `Cannot delegate set('${key}', ${value}) to the 'content' property of the internal session: its 'content' is undefined.`,
       content
     );
-    this._replaceContent(Object.assign({}, content, { [key]: value }));
+    let result = set(content, key, value);
     this.notifyPropertyChange(key);
     if (!/^_/.test(key)) {
       this._updateStore();
     }
-    return value;
+    return result;
   }
 
   _updateStore() {
     let data = this.content;
     if (!isEmpty(this.authenticator)) {
-      data = Object.assign({}, data, {
-        authenticated: Object.assign({ authenticator: this.authenticator }, data.authenticated || {}),
-      });
-      this._replaceContent(data);
+      set(
+        data,
+        'authenticated',
+        Object.assign({ authenticator: this.authenticator }, data.authenticated || {})
+      );
     }
     return this.store.persist(data);
   }
@@ -324,7 +327,7 @@ export default class InternalSession extends EmberObject {
           const authenticator = this._findAuthenticator(authenticatorFactory);
           authenticator.restore(content.authenticated).then(
             authenticatedContent => {
-              this._replaceContent(content);
+              this.set('content', content);
               this._busy = false;
               this._setup(authenticatorFactory, authenticatedContent, true);
             },
@@ -367,21 +370,26 @@ export default class InternalSession extends EmberObject {
       }
     }
 
-    if (typeof authenticatorRef === 'string' && authenticatorRef.includes(':')) {
-      const fromRegistry = getOwner(this).lookup(authenticatorRef);
-      if (!isNone(fromRegistry)) {
-        return fromRegistry;
-      }
+    if (
+      Configuration.useResolver &&
+      typeof authenticatorRef === 'string' &&
+      authenticatorRef.includes(':')
+    ) {
+      return this._lookupAuthenticator(authenticatorRef);
     }
 
+    assert(`No authenticator for factory "${authenticatorRef}" could be found!`, false);
+  }
+
+  _lookupAuthenticator(authenticatorName) {
+    let owner = getOwner(this);
+    let authenticator = owner.lookup(authenticatorName);
     assert(
-      'Ember Simple Auth: InternalSession requires createAuthenticators when useResolver is false.',
-      Boolean(this._authenticators) || Configuration.useResolver
+      `No authenticator for factory "${authenticatorName}" could be found!`,
+      !isNone(authenticator)
     );
-    assert(
-      `No authenticator for factory "${authenticatorRef}" could be found!`,
-      false
-    );
+    setOwner(authenticator, owner);
+    return authenticator;
   }
 
   on(event, cb) {

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -6,6 +6,8 @@ import { isTesting } from '@embroider/macros';
 import Configuration from '../configuration';
 import InternalSession from '../internal-session';
 import Ephemeral from '../session-stores/ephemeral';
+import TestAuthenticator from '../authenticators/test';
+import type EsaBaseAuthenticator from '../authenticators/base';
 
 import {
   requireAuthentication,
@@ -98,10 +100,9 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
           url: 'https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#resolver-registration',
         });
       } else {
-        this.session = new InternalSession(
-          owner,
-          setupStore(this.createSessionStore(owner))
-        ) as unknown as InternalSessionMock<Data>;
+        this.session = new InternalSession(owner, setupStore(this.createSessionStore(owner)), {
+          createAuthenticator: (name: string) => this.createAuthenticator(owner, name),
+        }) as unknown as InternalSessionMock<Data>;
       }
 
       associateDestroyableChild(this, this.session);
@@ -136,6 +137,45 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     }
 
     assert('Ember Simple Auth: implement createSessionStore on the session service.', false);
+  }
+
+  /**
+    Constructs an authenticator by name. Override this to use the authenticators
+    of your choice.
+
+    ```js
+    // app/services/session.js
+    import SessionService from 'ember-simple-auth/services/session';
+    import OAuth2 from '../authenticators/oauth2';
+
+    export default class Session extends SessionService {
+      createAuthenticator(owner, name) {
+        if (name === 'authenticator:oauth2' || name === 'oauth2') {
+          return new OAuth2(owner);
+        }
+      }
+    }
+    ```
+
+    Persist and restore still use the same authenticator name
+    (`authenticator:oauth2`).
+
+    @memberof SessionService
+    @method createAuthenticator
+    @param {Object} owner The application owner
+    @param {String} name The authenticator name passed to `authenticate` / stored on the session
+    @return {BaseAuthenticator} The authenticator instance
+    @public
+  */
+  createAuthenticator(owner: any, name: string): EsaBaseAuthenticator {
+    if (isTesting() && name === 'authenticator:test') {
+      return new TestAuthenticator(owner);
+    }
+
+    assert(
+      `Ember Simple Auth: implement createAuthenticator on the session service (unknown authenticator "${name}").`,
+      false
+    );
   }
 
   /**
@@ -430,7 +470,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
 
   /**
     Stores the `redirectTarget` in both `globalThis.sessionStorage` and the configured `session-store`.
-    Key is computed based on the `session-store:application` `key` or `cookieName` property.
+    Key is computed based on the session store `key` or `cookieName` property.
 
     This method is internally called by {@linkplain SessionService.requireAuthentication}.
 
@@ -447,7 +487,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
 
   /**
     Retrieves the `redirectTarget` from `globalThis.sessionStorage` first,
-    falls back to `session-store:application` when nothing's found.
+    falls back to the session store when nothing's found.
 
     This method is internally called by {@linkplain SessionService.handleAuthentication}.
 
@@ -466,7 +506,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
   }
 
   /**
-    Clears the `redirectTarget` from `globalThis.sessionStorage` and the `session-store:application`.
+    Clears the `redirectTarget` from `globalThis.sessionStorage` and the session store.
 
     This method is internally called by {@linkplain SessionService.handleAuthentication}.
 

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -2,8 +2,10 @@ import Service from '@ember/service';
 import { getOwner } from '@ember/application';
 import { assert, deprecate } from '@ember/debug';
 import { associateDestroyableChild } from '@ember/destroyable';
+import { isTesting } from '@embroider/macros';
 import Configuration from '../configuration';
 import InternalSession from '../internal-session';
+import Ephemeral from '../session-stores/ephemeral';
 
 import {
   requireAuthentication,
@@ -14,7 +16,7 @@ import {
 } from '../-internals/routing';
 import type Transition from '@ember/routing/transition';
 import { alias, readOnly } from '@ember/object/computed';
-import type EsaBaseSessionStore from '../session-stores/base';
+import EsaBaseSessionStore, { setupStore } from '../session-stores/base';
 
 const SESSION_DATA_KEY_PREFIX = /^data\./;
 
@@ -82,7 +84,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     super(owner);
 
     if (!this.session) {
-      if (Configuration.useInternalSessionLookup) {
+      if (Configuration.useResolver) {
         this.session = owner.lookup('session:main');
         assert('Ember Simple Auth: session:main is not registered.', this.session);
         deprecate('Ember Simple Auth: session:main resolver lookup is deprecated.', false, {
@@ -93,14 +95,47 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
             available: '8.4.0',
             enabled: '8.4.0',
           },
-          url: 'https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#sessionmain-resolver-registration',
+          url: 'https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#resolver-registration',
         });
       } else {
-        this.session = new InternalSession(owner) as unknown as InternalSessionMock<Data>;
+        this.session = new InternalSession(
+          owner,
+          setupStore(this.createSessionStore(owner))
+        ) as unknown as InternalSessionMock<Data>;
       }
 
       associateDestroyableChild(this, this.session);
     }
+  }
+
+  /**
+    Constructs the session store. Override this to use the session-store of your choice.
+    If you have a `app/session-stores/application`, you can import it directly and initialize in this method.
+
+    ```js
+    // app/services/session.js
+    import SessionService from 'ember-simple-auth/services/session';
+    import SessionStore from '../session-stores/application';
+
+    export default class Session extends SessionService {
+      createSessionStore(owner) {
+        return new SessionStore(owner);
+      }
+    }
+    ```
+
+    @memberof SessionService
+    @method createSessionStore
+    @param {Object} owner The application owner
+    @return {BaseStore} The session store instance
+    @public
+  */
+  createSessionStore(owner: any): EsaBaseSessionStore {
+    if (isTesting()) {
+      return new Ephemeral(owner);
+    }
+
+    assert('Ember Simple Auth: implement createSessionStore on the session service.', false);
   }
 
   /**

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -17,7 +17,6 @@ import {
   handleSessionInvalidated,
 } from '../-internals/routing';
 import type Transition from '@ember/routing/transition';
-import { alias, readOnly } from '@ember/object/computed';
 import EsaBaseSessionStore, { setupStore } from '../session-stores/base';
 
 const SESSION_DATA_KEY_PREFIX = /^data\./;
@@ -37,7 +36,7 @@ type InternalSessionMock<Data> = {
   isAuthenticated: boolean;
   content: Data;
   store: unknown;
-  attemptedTransition: null;
+  attemptedTransition: null | Transition;
   on: (event: 'authenticationSucceeded' | 'invalidationSucceeded', cb: () => void) => void;
   authenticate: (authenticator: string, ...args: any[]) => Promise<void>;
   invalidate: (...args: any[]) => Promise<void>;
@@ -189,7 +188,9 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default false
     @public
   */
-  @readOnly('session.isAuthenticated') declare isAuthenticated: boolean;
+  get isAuthenticated(): boolean {
+    return Boolean(this.session?.isAuthenticated);
+  }
 
   /**
     The current session data as a plain object. The
@@ -206,7 +207,9 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default { authenticated: {} }
     @public
   */
-  @readOnly('session.content') declare data: Data;
+  get data(): Data {
+    return (this.session?.content ?? { authenticated: {} }) as Data;
+  }
 
   /**
     The session store.
@@ -218,7 +221,9 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default null
     @public
   */
-  @readOnly('session.store') declare store: unknown;
+  get store(): unknown {
+    return this.session?.store;
+  }
 
   /**
     A previously attempted but intercepted transition (e.g. by the
@@ -234,8 +239,15 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default null
     @public
   */
-  @alias('session.attemptedTransition')
-  attemptedTransition: null | Transition = null;
+  get attemptedTransition(): null | Transition {
+    return this.session?.attemptedTransition ?? null;
+  }
+
+  set attemptedTransition(value: null | Transition) {
+    if (this.session) {
+      this.session.attemptedTransition = value;
+    }
+  }
 
   get redirectTargetKey(): string | null {
     const store = this.store as { key?: string; cookieName?: string };

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -36,6 +36,7 @@ type InternalSessionMock<Data> = {
   content: Data;
   store: unknown;
   attemptedTransition: null | Transition;
+  _authenticators?: EsaBaseAuthenticator[] | null;
   on: (event: 'authenticationSucceeded' | 'invalidationSucceeded', cb: () => void) => void;
   authenticate: (authenticator: AuthenticatorReference, ...args: any[]) => Promise<void>;
   invalidate: (...args: any[]) => Promise<void>;
@@ -103,6 +104,13 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
           },
           url: 'https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#resolver-registration',
         });
+        if (typeof this.createAuthenticators === 'function' && !this.session._authenticators) {
+          const authenticators = this.createAuthenticators(owner);
+          this.session._authenticators = authenticators;
+          authenticators.forEach(authenticator => {
+            associateDestroyableChild(this.session, authenticator);
+          });
+        }
       } else {
         assert(
           'Ember Simple Auth: implement createAuthenticators on the session service.',

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -6,7 +6,6 @@ import { isTesting } from '@embroider/macros';
 import Configuration from '../configuration';
 import InternalSession from '../internal-session';
 import Ephemeral from '../session-stores/ephemeral';
-import TestAuthenticator from '../authenticators/test';
 import type EsaBaseAuthenticator from '../authenticators/base';
 
 import {
@@ -38,7 +37,7 @@ type InternalSessionMock<Data> = {
   store: unknown;
   attemptedTransition: null | Transition;
   on: (event: 'authenticationSucceeded' | 'invalidationSucceeded', cb: () => void) => void;
-  authenticate: (authenticator: string, ...args: any[]) => Promise<void>;
+  authenticate: (authenticator: AuthenticatorReference, ...args: any[]) => Promise<void>;
   invalidate: (...args: any[]) => Promise<void>;
   restore: () => Promise<void>;
   set(key: string, value: any): void;
@@ -46,6 +45,12 @@ type InternalSessionMock<Data> = {
   getRedirectTarget: EsaBaseSessionStore['getRedirectTarget'];
   clearRedirectTarget: EsaBaseSessionStore['clearRedirectTarget'];
 };
+
+export type AuthenticatorClass = (new (...args: any[]) => EsaBaseAuthenticator) & {
+  id: string;
+};
+
+export type AuthenticatorReference = string | EsaBaseAuthenticator | AuthenticatorClass;
 
 export type ExtraAuthenticationArgs = {
   redirectTarget?: string;
@@ -99,6 +104,10 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
           url: 'https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#resolver-registration',
         });
       } else {
+        assert(
+          'Ember Simple Auth: implement createAuthenticators on the session service.',
+          typeof this.createAuthenticators === 'function'
+        );
         this.session = new InternalSession(owner, setupStore(this.createSessionStore(owner)), {
           authenticators: this.createAuthenticators(owner),
         }) as unknown as InternalSessionMock<Data>;
@@ -139,9 +148,8 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
   }
 
   /**
-    Constructs the authenticators used by this session. Override this to use the
-    authenticators of your choice. Keys must match the names passed to
-    `authenticate` and persisted on the session.
+    Constructs the authenticators used by this session. Declare this to use the
+    authenticators of your choice. Each instance needs a static id.
 
     ```js
     // app/services/session.js
@@ -150,9 +158,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
 
     export default class Session extends SessionService {
       createAuthenticators(owner) {
-        return {
-          'authenticator:oauth2': new OAuth2(owner),
-        };
+        return [new OAuth2(owner)];
       }
     }
     ```
@@ -160,18 +166,10 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @memberof SessionService
     @method createAuthenticators
     @param {Object} owner The application owner
-    @return {Object} Authenticator instances keyed by name
+    @return {Array} Authenticator instances
     @public
   */
-  createAuthenticators(owner: any): Record<string, EsaBaseAuthenticator> {
-    if (isTesting()) {
-      return {
-        'authenticator:test': new TestAuthenticator(owner),
-      };
-    }
-
-    assert('Ember Simple Auth: implement createAuthenticators on the session service.', false);
-  }
+  createAuthenticators?(owner: any): EsaBaseAuthenticator[];
 
   /**
    * Says whether the service was correctly initialized by the {#linkplain SessionService.setup}
@@ -299,12 +297,12 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
 
     @memberof SessionService
     @method authenticate
-    @param {String} authenticator The authenticator to use to authenticate the session
+    @param {String|BaseAuthenticator|Function} authenticator The authenticator to use to authenticate the session
     @param {Any} [...args] The arguments to pass to the authenticator; depending on the type of authenticator these might be a set of credentials, a Facebook OAuth Token, etc.
     @return {Promise} A promise that resolves when the session was authenticated successfully and rejects otherwise
     @public
   */
-  authenticate(authenticator: string, ...args: any[]) {
+  authenticate(authenticator: AuthenticatorReference, ...args: any[]) {
     return this.session.authenticate(authenticator, ...args);
   }
 

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -101,7 +101,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
         });
       } else {
         this.session = new InternalSession(owner, setupStore(this.createSessionStore(owner)), {
-          createAuthenticator: (name: string) => this.createAuthenticator(owner, name),
+          authenticators: this.createAuthenticators(owner),
         }) as unknown as InternalSessionMock<Data>;
       }
 
@@ -140,8 +140,9 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
   }
 
   /**
-    Constructs an authenticator by name. Override this to use the authenticators
-    of your choice.
+    Constructs the authenticators used by this session. Override this to use the
+    authenticators of your choice. Keys must match the names passed to
+    `authenticate` and persisted on the session.
 
     ```js
     // app/services/session.js
@@ -149,33 +150,28 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     import OAuth2 from '../authenticators/oauth2';
 
     export default class Session extends SessionService {
-      createAuthenticator(owner, name) {
-        if (name === 'authenticator:oauth2' || name === 'oauth2') {
-          return new OAuth2(owner);
-        }
+      createAuthenticators(owner) {
+        return {
+          'authenticator:oauth2': new OAuth2(owner),
+        };
       }
     }
     ```
 
-    Persist and restore still use the same authenticator name
-    (`authenticator:oauth2`).
-
     @memberof SessionService
-    @method createAuthenticator
+    @method createAuthenticators
     @param {Object} owner The application owner
-    @param {String} name The authenticator name passed to `authenticate` / stored on the session
-    @return {BaseAuthenticator} The authenticator instance
+    @return {Object} Authenticator instances keyed by name
     @public
   */
-  createAuthenticator(owner: any, name: string): EsaBaseAuthenticator {
-    if (isTesting() && name === 'authenticator:test') {
-      return new TestAuthenticator(owner);
+  createAuthenticators(owner: any): Record<string, EsaBaseAuthenticator> {
+    if (isTesting()) {
+      return {
+        'authenticator:test': new TestAuthenticator(owner),
+      };
     }
 
-    assert(
-      `Ember Simple Auth: implement createAuthenticator on the session service (unknown authenticator "${name}").`,
-      false
-    );
+    assert('Ember Simple Auth: implement createAuthenticators on the session service.', false);
   }
 
   /**

--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -16,6 +16,7 @@ import {
   handleSessionInvalidated,
 } from '../-internals/routing';
 import type Transition from '@ember/routing/transition';
+import { alias, readOnly } from '@ember/object/computed';
 import EsaBaseSessionStore, { setupStore } from '../session-stores/base';
 
 const SESSION_DATA_KEY_PREFIX = /^data\./;
@@ -36,7 +37,6 @@ type InternalSessionMock<Data> = {
   content: Data;
   store: unknown;
   attemptedTransition: null | Transition;
-  _authenticators?: EsaBaseAuthenticator[] | null;
   on: (event: 'authenticationSucceeded' | 'invalidationSucceeded', cb: () => void) => void;
   authenticate: (authenticator: AuthenticatorReference, ...args: any[]) => Promise<void>;
   invalidate: (...args: any[]) => Promise<void>;
@@ -84,7 +84,7 @@ export type DefaultDataShape = {
   @extends Service
   @public
 */
-export default class SessionService<Data = DefaultDataShape> extends Service {
+export default class SessionService<Data = DefaultDataShape, Store = unknown> extends Service {
   session!: InternalSessionMock<Data>;
 
   constructor(owner: any) {
@@ -104,13 +104,6 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
           },
           url: 'https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v9.md#resolver-registration',
         });
-        if (typeof this.createAuthenticators === 'function' && !this.session._authenticators) {
-          const authenticators = this.createAuthenticators(owner);
-          this.session._authenticators = authenticators;
-          authenticators.forEach(authenticator => {
-            associateDestroyableChild(this.session, authenticator);
-          });
-        }
       } else {
         assert(
           'Ember Simple Auth: implement createAuthenticators on the session service.',
@@ -147,9 +140,10 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @return {BaseStore} The session store instance
     @public
   */
-  createSessionStore(owner: any): EsaBaseSessionStore {
+  createSessionStore(owner: any): EsaBaseSessionStore & Store {
     if (isTesting()) {
-      return new Ephemeral(owner);
+      const store: EsaBaseSessionStore = new Ephemeral(owner);
+      return store as EsaBaseSessionStore & Store;
     }
 
     assert('Ember Simple Auth: implement createSessionStore on the session service.', false);
@@ -194,9 +188,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default false
     @public
   */
-  get isAuthenticated(): boolean {
-    return Boolean(this.session?.isAuthenticated);
-  }
+  @readOnly('session.isAuthenticated') declare isAuthenticated: boolean;
 
   /**
     The current session data as a plain object. The
@@ -213,9 +205,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default { authenticated: {} }
     @public
   */
-  get data(): Data {
-    return (this.session?.content ?? { authenticated: {} }) as Data;
-  }
+  @readOnly('session.content') declare data: Data;
 
   /**
     The session store.
@@ -227,9 +217,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default null
     @public
   */
-  get store(): unknown {
-    return this.session?.store;
-  }
+  @readOnly('session.store') declare store: Store;
 
   /**
     A previously attempted but intercepted transition (e.g. by the
@@ -245,15 +233,8 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default null
     @public
   */
-  get attemptedTransition(): null | Transition {
-    return this.session?.attemptedTransition ?? null;
-  }
-
-  set attemptedTransition(value: null | Transition) {
-    if (this.session) {
-      this.session.attemptedTransition = value;
-    }
-  }
+  @alias('session.attemptedTransition')
+  attemptedTransition: null | Transition = null;
 
   get redirectTargetKey(): string | null {
     const store = this.store as { key?: string; cookieName?: string };

--- a/packages/ember-simple-auth/src/session-stores/adaptive.ts
+++ b/packages/ember-simple-auth/src/session-stores/adaptive.ts
@@ -1,11 +1,13 @@
 import { computed } from '@ember/object';
 import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
-import Base from './base';
-import type CookiesService from 'ember-cookies/services/cookies';
-import type CookieStore from './cookie';
-import type LocalStorageStore from './local-storage';
+import { associateDestroyableChild } from '@ember/destroyable';
 import { debug } from '@ember/debug';
+import Base, { setupStore } from './base';
+import Configuration from '../configuration';
+import CookieStore from './cookie';
+import LocalStorageStore from './local-storage';
+import type CookiesService from 'ember-cookies/services/cookies';
 
 const LOCAL_STORAGE_TEST_KEY = '_ember_simple_auth_test_key';
 
@@ -152,7 +154,6 @@ export default class AdaptiveStore extends Base {
 
   @service('cookies') declare _cookies: CookiesService;
   declare _fastboot: any;
-
   declare _store: CookieStore | LocalStorageStore;
 
   __isLocalStorageAvailable: boolean | null = null;
@@ -174,6 +175,10 @@ export default class AdaptiveStore extends Base {
       );
     }
 
+    this._ensureSetup();
+  }
+
+  _setup() {
     let owner = getOwner(this) as any;
     if (owner && !this.hasOwnProperty('_fastboot')) {
       this._fastboot = owner.lookup('service:fastboot');
@@ -181,31 +186,45 @@ export default class AdaptiveStore extends Base {
 
     let store;
     if (this.get('_isLocalStorageAvailable')) {
-      const localStorage = owner.lookup('session-store:local-storage');
-      const options = { key: this.get('localStorageKey'), _isFastBoot: false };
-
-      localStorage.setProperties(options);
-
+      const localStorage = this._createOrLookupStore(
+        owner,
+        'session-store:local-storage',
+        LocalStorageStore
+      );
+      localStorage.setProperties({ key: this.get('localStorageKey'), _isFastBoot: false });
       store = localStorage;
     } else {
-      const cookieStorage = owner.lookup('session-store:cookie');
-      const options = this.getProperties(
-        'cookieDomain',
-        'cookieName',
-        'cookieExpirationTime',
-        'cookiePath',
-        'sameSite',
-        'partitioned'
+      const cookieStorage = this._createOrLookupStore(owner, 'session-store:cookie', CookieStore);
+      cookieStorage.setProperties(
+        this.getProperties(
+          'cookieDomain',
+          'cookieName',
+          'cookieExpirationTime',
+          'cookiePath',
+          'sameSite',
+          'partitioned'
+        )
       );
-
-      cookieStorage.setProperties(options);
       this.set('cookieExpirationTime', cookieStorage.get('cookieExpirationTime'));
-
       store = cookieStorage;
     }
 
     this.set('_store', store);
     this._setupStoreEvents(store);
+  }
+
+  _createOrLookupStore(
+    owner: any,
+    factoryName: string,
+    Store: typeof CookieStore | typeof LocalStorageStore
+  ) {
+    if (Configuration.useResolver) {
+      return owner.lookup(factoryName);
+    }
+
+    const store = setupStore(new Store(owner));
+    associateDestroyableChild(this, store);
+    return store;
   }
 
   _setupStoreEvents(store: CookieStore | LocalStorageStore) {

--- a/packages/ember-simple-auth/src/session-stores/adaptive.ts
+++ b/packages/ember-simple-auth/src/session-stores/adaptive.ts
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { associateDestroyableChild } from '@ember/destroyable';
 import { debug } from '@ember/debug';
-import Base, { setupStore } from './base';
+import Base, { SESSION_STORE_SETUP, setupStore } from './base';
 import Configuration from '../configuration';
 import CookieStore from './cookie';
 import LocalStorageStore from './local-storage';
@@ -175,10 +175,10 @@ export default class AdaptiveStore extends Base {
       );
     }
 
-    this._ensureSetup();
+    setupStore(this);
   }
 
-  _setup() {
+  [SESSION_STORE_SETUP]() {
     let owner = getOwner(this) as any;
     if (owner && !this.hasOwnProperty('_fastboot')) {
       this._fastboot = owner.lookup('service:fastboot');

--- a/packages/ember-simple-auth/src/session-stores/adaptive.ts
+++ b/packages/ember-simple-auth/src/session-stores/adaptive.ts
@@ -1,4 +1,5 @@
-import { computed } from '@ember/object';
+import { computed, notifyPropertyChange } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { associateDestroyableChild } from '@ember/destroyable';
@@ -148,9 +149,19 @@ export default class AdaptiveStore extends Base {
     @type Integer
     @public
   */
-  _cookieExpirationTime = null;
-  @proxyToInternalStore()
-  cookieExpirationTime!: number | null;
+  @tracked _cookieExpirationTime: number | null = null;
+
+  get cookieExpirationTime(): number | null {
+    return this._cookieExpirationTime;
+  }
+
+  set cookieExpirationTime(value: number | null) {
+    this._cookieExpirationTime = value;
+    if (this._store) {
+      this._store.set('cookieExpirationTime', value);
+    }
+    notifyPropertyChange(this, 'cookieExpirationTime');
+  }
 
   @service('cookies') declare _cookies: CookiesService;
   declare _fastboot: any;

--- a/packages/ember-simple-auth/src/session-stores/base.ts
+++ b/packages/ember-simple-auth/src/session-stores/base.ts
@@ -7,6 +7,11 @@ export interface SessionEvents {
 
 class SessionStoreEventTarget extends EsaEventTarget<SessionEvents> {}
 
+export function setupStore<T extends EsaBaseSessionStore>(store: T): T {
+  store._ensureSetup();
+  return store;
+}
+
 /**
   The base class for all session stores. __This serves as a starting point for
   implementing custom session stores and must not be used directly.__
@@ -20,6 +25,20 @@ class SessionStoreEventTarget extends EsaEventTarget<SessionEvents> {}
 */
 export default abstract class EsaBaseSessionStore extends EmberObject {
   sessionStoreEvents = new SessionStoreEventTarget();
+  _setupRan = false;
+
+  _ensureSetup() {
+    if (this._setupRan) {
+      return this;
+    }
+
+    this._setupRan = true;
+    this._setup();
+    return this;
+  }
+
+  _setup() {}
+
   /**
     Triggered when the session store's data changes due to an external event,
     e.g., from another tab or window of the same application. The session

--- a/packages/ember-simple-auth/src/session-stores/base.ts
+++ b/packages/ember-simple-auth/src/session-stores/base.ts
@@ -7,8 +7,14 @@ export interface SessionEvents {
 
 class SessionStoreEventTarget extends EsaEventTarget<SessionEvents> {}
 
+const initializedStores = new WeakSet<EsaBaseSessionStore>();
+export const SESSION_STORE_SETUP = Symbol('ember-simple-auth-session-store-setup');
+
 export function setupStore<T extends EsaBaseSessionStore>(store: T): T {
-  store._ensureSetup();
+  if (!initializedStores.has(store)) {
+    initializedStores.add(store);
+    store[SESSION_STORE_SETUP]();
+  }
   return store;
 }
 
@@ -25,19 +31,8 @@ export function setupStore<T extends EsaBaseSessionStore>(store: T): T {
 */
 export default abstract class EsaBaseSessionStore extends EmberObject {
   sessionStoreEvents = new SessionStoreEventTarget();
-  _setupRan = false;
 
-  _ensureSetup() {
-    if (this._setupRan) {
-      return this;
-    }
-
-    this._setupRan = true;
-    this._setup();
-    return this;
-  }
-
-  _setup() {}
+  [SESSION_STORE_SETUP]() {}
 
   /**
     Triggered when the session store's data changes due to an external event,

--- a/packages/ember-simple-auth/src/session-stores/cookie.ts
+++ b/packages/ember-simple-auth/src/session-stores/cookie.ts
@@ -213,7 +213,10 @@ export default class CookieStore extends BaseStore {
 
   init(properties: any) {
     super.init(properties);
+    this._ensureSetup();
+  }
 
+  _setup() {
     this._fastboot = (getOwner(this) as any).lookup('service:fastboot');
 
     const cachedExpirationTime = this._read(`${this.get('cookieName')}-expiration_time`);

--- a/packages/ember-simple-auth/src/session-stores/cookie.ts
+++ b/packages/ember-simple-auth/src/session-stores/cookie.ts
@@ -1,4 +1,5 @@
-import { computed } from '@ember/object';
+import { computed, notifyPropertyChange } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import { later, cancel, scheduleOnce, next, type Timer } from '@ember/runloop';
 import { typeOf, isEmpty, isNone } from '@ember/utils';
@@ -43,16 +44,14 @@ const persistingProperty = function (beforeSet = function (_key: string, _value:
 
   export default class LoginController extends Controller {
     &#64;service session;
-    _rememberMe = false;
 
     get rememberMe() {
-      return this._rememberMe;
+      return this.session.store.cookieExpirationTime !== null;
     }
 
     set rememberMe(value) {
       let expirationTime = value ? (14 * 24 * 60 * 60) : null;
-      this.set('session.store.cookieExpirationTime', expirationTime);
-      this._rememberMe = value;
+      this.session.store.cookieExpirationTime = expirationTime;
     }
   }
   ```
@@ -151,8 +150,13 @@ export default class CookieStore extends BaseStore {
     @type Integer
     @public
   */
-  _cookieExpirationTime = null;
-  @persistingProperty(function (this: CookieStore, key, value) {
+  @tracked _cookieExpirationTime: number | null = null;
+
+  get cookieExpirationTime(): number | null {
+    return this._cookieExpirationTime;
+  }
+
+  set cookieExpirationTime(value: number | null) {
     // When nulling expiry time on purpose, we need to clear the cached value.
     // Otherwise, `_calculateExpirationTime` will reuse it.
     if (isNone(value)) {
@@ -164,8 +168,10 @@ export default class CookieStore extends BaseStore {
         { id: 'ember-simple-auth.cookieExpirationTime' }
       );
     }
-  })
-  cookieExpirationTime!: number | null;
+    this._cookieExpirationTime = value;
+    notifyPropertyChange(this, 'cookieExpirationTime');
+    scheduleOnce('actions', this, this.rewriteCookie);
+  }
 
   /**
     Allows servers to assert that a cookie should opt in to partitioned storage,

--- a/packages/ember-simple-auth/src/session-stores/cookie.ts
+++ b/packages/ember-simple-auth/src/session-stores/cookie.ts
@@ -4,7 +4,7 @@ import { later, cancel, scheduleOnce, next, type Timer } from '@ember/runloop';
 import { typeOf, isEmpty, isNone } from '@ember/utils';
 import { A } from '@ember/array';
 import { warn } from '@ember/debug';
-import BaseStore from './base';
+import BaseStore, { SESSION_STORE_SETUP, setupStore } from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
 import { isTesting } from '@embroider/macros';
 import type CookiesService from 'ember-cookies/services/cookies';
@@ -213,10 +213,10 @@ export default class CookieStore extends BaseStore {
 
   init(properties: any) {
     super.init(properties);
-    this._ensureSetup();
+    setupStore(this);
   }
 
-  _setup() {
+  [SESSION_STORE_SETUP]() {
     this._fastboot = (getOwner(this) as any).lookup('service:fastboot');
 
     const cachedExpirationTime = this._read(`${this.get('cookieName')}-expiration_time`);

--- a/packages/ember-simple-auth/src/test-support/index.ts
+++ b/packages/ember-simple-auth/src/test-support/index.ts
@@ -1,11 +1,16 @@
 import { get } from '@ember/object';
 import { getContext, settled } from '@ember/test-helpers';
 import Test from '../authenticators/test';
+import Configuration from '../configuration';
 
 const SESSION_SERVICE_KEY = 'service:session';
 const TEST_CONTAINER_KEY = 'authenticator:test';
 
 function ensureAuthenticator(owner: any) {
+  if (!Configuration.useResolver) {
+    return;
+  }
+
   const authenticator = owner.lookup(TEST_CONTAINER_KEY);
   if (!authenticator) {
     owner.register(TEST_CONTAINER_KEY, Test);

--- a/packages/ember-simple-auth/src/test-support/index.ts
+++ b/packages/ember-simple-auth/src/test-support/index.ts
@@ -6,15 +6,22 @@ import Configuration from '../configuration';
 const SESSION_SERVICE_KEY = 'service:session';
 const TEST_CONTAINER_KEY = 'authenticator:test';
 
-function ensureAuthenticator(owner: any) {
-  if (!Configuration.useResolver) {
-    return;
+function ensureAuthenticator(session: any, owner: any) {
+  if (Configuration.useResolver) {
+    const authenticator = owner.lookup(TEST_CONTAINER_KEY);
+    if (!authenticator) {
+      owner.register(TEST_CONTAINER_KEY, Test);
+    }
+    return TEST_CONTAINER_KEY;
   }
 
-  const authenticator = owner.lookup(TEST_CONTAINER_KEY);
+  const authenticators = session.session._authenticators || [];
+  let authenticator = authenticators.find((candidate: Test) => candidate.constructor === Test);
   if (!authenticator) {
-    owner.register(TEST_CONTAINER_KEY, Test);
+    authenticator = new Test(owner);
+    session.session._setAuthenticators([...authenticators, authenticator]);
   }
+  return authenticator;
 }
 
 /**
@@ -28,9 +35,8 @@ function ensureAuthenticator(owner: any) {
 export async function authenticateSession(sessionData: Record<string, any>) {
   const { owner } = getContext() as { owner: any };
   const session = owner.lookup(SESSION_SERVICE_KEY);
-  ensureAuthenticator(owner);
 
-  await session.authenticate(TEST_CONTAINER_KEY, sessionData);
+  await session.authenticate(ensureAuthenticator(session, owner), sessionData);
   await settled();
 }
 

--- a/packages/playwright-tests/package.json
+++ b/packages/playwright-tests/package.json
@@ -13,7 +13,8 @@
     "lint": "prettier --check . && ESLINT_USE_FLAT_CONFIG=true eslint .",
     "lint:fix": "prettier --write . && ESLINT_USE_FLAT_CONFIG=true eslint . --fix",
     "test:e2e:firefox": "pnpm test:e2e --project=firefox",
-    "test:e2e:chromium": "pnpm test:e2e --project=chromium"
+    "test:e2e:chromium": "pnpm test:e2e --project=chromium",
+    "test:e2e:no-resolver": "PUBLIC_ESA_USE_RESOLVER=false pnpm test:e2e:chromium"
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",

--- a/packages/playwright-tests/tests/test-app.spec.ts
+++ b/packages/playwright-tests/tests/test-app.spec.ts
@@ -38,6 +38,18 @@ STORAGE_SCENARIOS.forEach(scenario => {
       await expect(page.getByRole('heading')).toHaveText('Ember Simple Auth example app');
     });
 
+    test('does not register session:main when useResolver is false', async ({ page }) => {
+      test.skip(
+        process.env.PUBLIC_ESA_USE_RESOLVER !== 'false',
+        'This assertion only applies when useResolver is false.'
+      );
+      await specifyTestAppStorageAdapter(page, scenario);
+      await page.goto('/');
+
+      await expect(page.getByTestId('use-resolver')).toHaveAttribute('data-use-resolver', 'false');
+      await expect(page.getByTestId('use-resolver')).toHaveAttribute('data-session-main', 'false');
+    });
+
     test('can log-in', async ({ page }) => {
       await specifyTestAppStorageAdapter(page, scenario);
       await page.goto('/');

--- a/packages/playwright-tests/tests/test-app.spec.ts
+++ b/packages/playwright-tests/tests/test-app.spec.ts
@@ -13,6 +13,7 @@ const loginWithPassword = async (page: Page) => {
 };
 
 const STORAGE_SCENARIOS = ['cookieStorage', 'localStorage', 'adaptive'] as const;
+const useResolver = process.env.PUBLIC_ESA_USE_RESOLVER !== 'false';
 
 const specifyTestAppStorageAdapter = async (
   page: Page,
@@ -38,16 +39,16 @@ STORAGE_SCENARIOS.forEach(scenario => {
       await expect(page.getByRole('heading')).toHaveText('Ember Simple Auth example app');
     });
 
-    test('does not register session:main when useResolver is false', async ({ page }) => {
-      test.skip(
-        process.env.PUBLIC_ESA_USE_RESOLVER !== 'false',
-        'This assertion only applies when useResolver is false.'
-      );
+    test(`initializes the session store with useResolver: ${useResolver}`, async ({ page }) => {
       await specifyTestAppStorageAdapter(page, scenario);
       await page.goto('/');
 
-      await expect(page.getByTestId('use-resolver')).toHaveAttribute('data-use-resolver', 'false');
-      await expect(page.getByTestId('use-resolver')).toHaveAttribute('data-session-main', 'false');
+      const session = page.getByTestId('use-resolver');
+      const expectedUseResolver = useResolver ? 'true' : 'false';
+      await expect(session).toHaveAttribute('data-use-resolver', expectedUseResolver);
+      await expect(session).toHaveAttribute('data-session-main', expectedUseResolver);
+      // Resolver-created stores retain EmberObject's init hook. Direct `new` does not call it.
+      await expect(session).toHaveAttribute('data-store-init-calls', useResolver ? '1' : '0');
     });
 
     test('can log-in', async ({ page }) => {
@@ -59,6 +60,19 @@ STORAGE_SCENARIOS.forEach(scenario => {
 
       await loginWithPassword(page);
       await confirmLoggedIn(page);
+
+      const persistedSession = await page.evaluate(() => ({
+        cookie: document.cookie
+          .split('; ')
+          .some(value => value.startsWith('ember_simple_auth-session=')),
+        localStorage: localStorage.getItem('ember_simple_auth-session') !== null,
+      }));
+      const expectsCookie =
+        process.env.FASTBOOT_DISABLED !== 'true' || scenario === 'cookieStorage';
+      expect(persistedSession).toEqual({
+        cookie: expectsCookie,
+        localStorage: !expectsCookie,
+      });
     });
 
     test('logged-in state is synchronized between tabs', async ({ page, context }) => {

--- a/packages/test-app/app/authenticators/oauth2-implicit-grant.js
+++ b/packages/test-app/app/authenticators/oauth2-implicit-grant.js
@@ -1,3 +1,5 @@
 import OAuth2ImplicitGrant from 'ember-simple-auth/authenticators/oauth2-implicit-grant';
 
-export default class OAuth2ImplicitGrantAuthenticator extends OAuth2ImplicitGrant {}
+export default class OAuth2ImplicitGrantAuthenticator extends OAuth2ImplicitGrant {
+  static id = 'oauth2-implicit-grant';
+}

--- a/packages/test-app/app/authenticators/oauth2-implicit-grant.js
+++ b/packages/test-app/app/authenticators/oauth2-implicit-grant.js
@@ -1,5 +1,3 @@
 import OAuth2ImplicitGrant from 'ember-simple-auth/authenticators/oauth2-implicit-grant';
 
-export default class OAuth2ImplicitGrantAuthenticator extends OAuth2ImplicitGrant {
-  static id = 'oauth2-implicit-grant';
-}
+export default class OAuth2ImplicitGrantAuthenticator extends OAuth2ImplicitGrant {}

--- a/packages/test-app/app/authenticators/oauth2.js
+++ b/packages/test-app/app/authenticators/oauth2.js
@@ -2,6 +2,7 @@ import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-passwor
 import config from '../config/environment';
 
 export default class OAuth2Authenticator extends OAuth2PasswordGrant {
+  static id = 'oauth2';
   serverTokenEndpoint = `${config.apiHost}/token`;
   serverTokenRevocationEndpoint = `${config.apiHost}/revoke`;
 }

--- a/packages/test-app/app/authenticators/torii.js
+++ b/packages/test-app/app/authenticators/torii.js
@@ -2,6 +2,7 @@ import { service } from '@ember/service';
 import Torii from 'ember-simple-auth/authenticators/torii';
 
 export default class ToriiAuthenticator extends Torii {
+  static id = 'torii';
   @service torii;
 
   authenticate() {

--- a/packages/test-app/app/authenticators/torii.js
+++ b/packages/test-app/app/authenticators/torii.js
@@ -2,7 +2,6 @@ import { service } from '@ember/service';
 import Torii from 'ember-simple-auth/authenticators/torii';
 
 export default class ToriiAuthenticator extends Torii {
-  static id = 'torii';
   @service torii;
 
   authenticate() {

--- a/packages/test-app/app/config/environment.d.ts
+++ b/packages/test-app/app/config/environment.d.ts
@@ -3,6 +3,9 @@ declare const config: {
   APP: string;
   modulePrefix: string;
   podModulePrefix: string;
+  'ember-simple-auth': {
+    useResolver: boolean;
+  };
 };
 
 export default config;

--- a/packages/test-app/app/config/environment.d.ts
+++ b/packages/test-app/app/config/environment.d.ts
@@ -4,7 +4,7 @@ declare const config: {
   modulePrefix: string;
   podModulePrefix: string;
   'ember-simple-auth': {
-    useResolver: boolean;
+    useResolver?: boolean;
   };
 };
 

--- a/packages/test-app/app/controllers/application.js
+++ b/packages/test-app/app/controllers/application.js
@@ -1,11 +1,21 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import { getOwner } from '@ember/application';
+import config from '../config/environment';
 
 export default class ApplicationController extends Controller {
   @service router;
   @service session;
   @service fastboot;
+
+  useResolver = config['ember-simple-auth'].useResolver ?? true;
+
+  get sessionMainRegistered() {
+    return Boolean(
+      getOwner(this).hasRegistration('session:main') || getOwner(this).factoryFor('session:main')
+    );
+  }
 
   @action
   transitionToLoginRoute() {

--- a/packages/test-app/app/services/session.ts
+++ b/packages/test-app/app/services/session.ts
@@ -27,12 +27,12 @@ export default class SessionService extends Session<Data> {
   }
 
   createAuthenticators(owner: any) {
-    return {
-      'authenticator:oauth2': new OAuth2(owner),
-      'authenticator:oauth2-implicit-grant': new OAuth2ImplicitGrant(owner),
-      'authenticator:torii': new Torii(owner),
-      ...(isTesting() ? { 'authenticator:test': new TestAuthenticator(owner) } : {}),
-    };
+    return [
+      new OAuth2(owner),
+      new OAuth2ImplicitGrant(owner),
+      new Torii(owner),
+      ...(isTesting() ? [new TestAuthenticator(owner)] : []),
+    ];
   }
 
   handleAuthentication(routeAfterInvalidation: string) {

--- a/packages/test-app/app/services/session.ts
+++ b/packages/test-app/app/services/session.ts
@@ -1,5 +1,12 @@
 import { service } from '@ember/service';
+import { isTesting } from '@embroider/macros';
 import Session from 'ember-simple-auth/services/session';
+import TestAuthenticator from 'ember-simple-auth/authenticators/test';
+import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
+import SessionStore from '../session-stores/application';
+import OAuth2 from '../authenticators/oauth2';
+import OAuth2ImplicitGrant from '../authenticators/oauth2-implicit-grant';
+import Torii from '../authenticators/torii';
 
 type Data = {
   authenticated: {
@@ -9,6 +16,24 @@ type Data = {
 
 export default class SessionService extends Session<Data> {
   @service declare sessionAccount: any;
+
+  createSessionStore(owner: any) {
+    const fastboot = owner.lookup('service:fastboot');
+    if (isTesting() && !fastboot?.isFastBoot) {
+      return new Ephemeral(owner);
+    }
+
+    return new SessionStore(owner);
+  }
+
+  createAuthenticators(owner: any) {
+    return {
+      'authenticator:oauth2': new OAuth2(owner),
+      'authenticator:oauth2-implicit-grant': new OAuth2ImplicitGrant(owner),
+      'authenticator:torii': new Torii(owner),
+      ...(isTesting() ? { 'authenticator:test': new TestAuthenticator(owner) } : {}),
+    };
+  }
 
   handleAuthentication(routeAfterInvalidation: string) {
     super.handleAuthentication(routeAfterInvalidation);

--- a/packages/test-app/app/services/session.ts
+++ b/packages/test-app/app/services/session.ts
@@ -1,7 +1,6 @@
 import { service } from '@ember/service';
 import { isTesting } from '@embroider/macros';
 import Session from 'ember-simple-auth/services/session';
-import TestAuthenticator from 'ember-simple-auth/authenticators/test';
 import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
 import SessionStore from '../session-stores/application';
 import OAuth2 from '../authenticators/oauth2';
@@ -27,12 +26,7 @@ export default class SessionService extends Session<Data> {
   }
 
   createAuthenticators(owner: any) {
-    return [
-      new OAuth2(owner),
-      new OAuth2ImplicitGrant(owner),
-      new Torii(owner),
-      ...(isTesting() ? [new TestAuthenticator(owner)] : []),
-    ];
+    return [new OAuth2(owner), new OAuth2ImplicitGrant(owner), new Torii(owner)];
   }
 
   handleAuthentication(routeAfterInvalidation: string) {

--- a/packages/test-app/app/session-stores/application.js
+++ b/packages/test-app/app/session-stores/application.js
@@ -2,13 +2,13 @@ import { macroCondition, getOwnConfig } from '@embroider/macros';
 import CookieStore from 'ember-simple-auth/session-stores/cookie';
 import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
 
-let klass = class extends CookieStore {};
+let klass = CookieStore;
 if (macroCondition(getOwnConfig().FASTBOOT_DISABLED)) {
   // Playwright testing
   klass = class extends AdaptiveStore {
-    init(emberOwner) {
-      let __isLocalStorageAvailable = determineStorageBackend();
-      super.init(emberOwner, __isLocalStorageAvailable);
+    constructor(owner) {
+      super(owner);
+      this.__isLocalStorageAvailable = determineStorageBackend();
     }
   };
   function determineStorageBackend() {
@@ -25,4 +25,12 @@ if (macroCondition(getOwnConfig().FASTBOOT_DISABLED)) {
   }
 }
 
-export default klass;
+export default class ApplicationSessionStore extends klass {
+  // Expose the legacy lifecycle to the Playwright compatibility test.
+  initCalls = 0;
+
+  init(...args) {
+    super.init(...args);
+    this.initCalls++;
+  }
+}

--- a/packages/test-app/app/templates/application.hbs
+++ b/packages/test-app/app/templates/application.hbs
@@ -4,6 +4,12 @@
 </div>
 
 <div data-test-fastboot={{this.fastboot.isFastBoot}} hidden></div>
+<div
+  data-testid='use-resolver'
+  data-use-resolver={{if this.useResolver 'true' 'false'}}
+  data-session-main={{if this.sessionMainRegistered 'true' 'false'}}
+  hidden
+></div>
 
 <div data-test-reactivity hidden>
   <!-- test SessionService reactivity -->

--- a/packages/test-app/app/templates/application.hbs
+++ b/packages/test-app/app/templates/application.hbs
@@ -8,4 +8,5 @@
 <div data-test-reactivity hidden>
   <!-- test SessionService reactivity -->
   <span data-is-authenticated={{this.session.isAuthenticated}}> </span>
+  <span data-access-token={{this.session.data.authenticated.access_token}}> </span>
 </div>

--- a/packages/test-app/app/templates/application.hbs
+++ b/packages/test-app/app/templates/application.hbs
@@ -8,6 +8,7 @@
   data-testid='use-resolver'
   data-use-resolver={{if this.useResolver 'true' 'false'}}
   data-session-main={{if this.sessionMainRegistered 'true' 'false'}}
+  data-store-init-calls={{this.session.store.initCalls}}
   hidden
 ></div>
 

--- a/packages/test-app/config/environment.js
+++ b/packages/test-app/config/environment.js
@@ -48,7 +48,7 @@ module.exports = function (environment) {
     },
 
     'ember-simple-auth': {
-      useResolver: process.env.ESA_USE_RESOLVER !== 'false',
+      ...(process.env.PUBLIC_ESA_USE_RESOLVER === 'false' ? { useResolver: false } : {}),
     },
   };
 

--- a/packages/test-app/config/environment.js
+++ b/packages/test-app/config/environment.js
@@ -46,6 +46,10 @@ module.exports = function (environment) {
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],
     },
+
+    'ember-simple-auth': {
+      useResolver: process.env.ESA_USE_RESOLVER !== 'false',
+    },
   };
 
   if (environment === 'development') {

--- a/packages/test-app/config/environment.js
+++ b/packages/test-app/config/environment.js
@@ -48,7 +48,7 @@ module.exports = function (environment) {
     },
 
     'ember-simple-auth': {
-      ...(process.env.PUBLIC_ESA_USE_RESOLVER === 'false' ? { useResolver: false } : {}),
+      useResolver: process.env.PUBLIC_ESA_USE_RESOLVER !== 'false',
     },
   };
 

--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     'ember-cli-babel': { enableTypeScriptTransform: true },
+    ...(process.env.PUBLIC_ESA_USE_RESOLVER === 'false'
+      ? { 'ember-simple-auth': { useResolver: false } }
+      : {}),
     '@embroider/macros': {
       setOwnConfig: {
         FASTBOOT_DISABLED: process.env.FASTBOOT_DISABLED === 'true',

--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -5,9 +5,6 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     'ember-cli-babel': { enableTypeScriptTransform: true },
-    ...(process.env.PUBLIC_ESA_USE_RESOLVER === 'false'
-      ? { 'ember-simple-auth': { useResolver: false } }
-      : {}),
     '@embroider/macros': {
       setOwnConfig: {
         FASTBOOT_DISABLED: process.env.FASTBOOT_DISABLED === 'true',

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -13,6 +13,7 @@
     "start:fastboot": "NODE_ENV=production node fastboot-server.js",
     "start:demo-api": "node server/demo-api.js",
     "test": "ember test",
+    "test:no-resolver": "ESA_USE_RESOLVER=false ember test",
     "test:all": "ember try:each",
     "test:one": "ember try:one",
     "test:fastboot": "ember fastboot:test"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -13,7 +13,7 @@
     "start:fastboot": "NODE_ENV=production node fastboot-server.js",
     "start:demo-api": "node server/demo-api.js",
     "test": "ember test",
-    "test:no-resolver": "ESA_USE_RESOLVER=false ember test",
+    "test:no-resolver": "PUBLIC_ESA_USE_RESOLVER=false ember test",
     "test:all": "ember try:each",
     "test:one": "ember try:one",
     "test:fastboot": "ember fastboot:test"

--- a/packages/test-app/tests/acceptance/authentication-test.ts
+++ b/packages/test-app/tests/acceptance/authentication-test.ts
@@ -9,9 +9,9 @@ import {
 } from 'ember-simple-auth/test-support';
 import config from 'test-app/config/environment';
 
-const useResolver = config['ember-simple-auth'].useResolver;
+const useResolver = config['ember-simple-auth'].useResolver ?? true;
 
-module(`Acceptance: Authentication (useResolver: ${useResolver})`, function (hooks) {
+module('Acceptance: Authentication', function (hooks) {
   setupApplicationTest(hooks);
   let server: Pretender;
 
@@ -21,12 +21,17 @@ module(`Acceptance: Authentication (useResolver: ${useResolver})`, function (hoo
     }
   });
 
-  test('boots with the configured useResolver flag', function (assert) {
+  test('does not register session:main when useResolver is false', function (assert) {
+    if (useResolver) {
+      assert.expect(0);
+      return;
+    }
+
     const { owner } = getContext() as { owner: { factoryFor: (name: string) => unknown } };
 
-    assert.strictEqual(config['ember-simple-auth'].useResolver, useResolver);
-    assert.strictEqual(Boolean(owner.factoryFor('session:main')), useResolver);
-    assert.strictEqual(Boolean(owner.factoryFor('session-store:cookie')), useResolver);
+    assert.false(config['ember-simple-auth'].useResolver);
+    assert.notOk(owner.factoryFor('session:main'));
+    assert.notOk(owner.factoryFor('session-store:cookie'));
   });
 
   test('logging in with correct credentials works', async function (assert) {

--- a/packages/test-app/tests/acceptance/authentication-test.ts
+++ b/packages/test-app/tests/acceptance/authentication-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { currentURL, visit, fillIn, click } from '@ember/test-helpers';
+import { currentURL, visit, fillIn, click, getContext } from '@ember/test-helpers';
 import Pretender from 'pretender';
 import {
   invalidateSession,
@@ -9,7 +9,9 @@ import {
 } from 'ember-simple-auth/test-support';
 import config from 'test-app/config/environment';
 
-module('Acceptance: Authentication', function (hooks) {
+const useResolver = config['ember-simple-auth'].useResolver;
+
+module(`Acceptance: Authentication (useResolver: ${useResolver})`, function (hooks) {
   setupApplicationTest(hooks);
   let server: Pretender;
 
@@ -17,6 +19,14 @@ module('Acceptance: Authentication', function (hooks) {
     if (server) {
       server.shutdown();
     }
+  });
+
+  test('boots with the configured useResolver flag', function (assert) {
+    const { owner } = getContext() as { owner: { factoryFor: (name: string) => unknown } };
+
+    assert.strictEqual(config['ember-simple-auth'].useResolver, useResolver);
+    assert.strictEqual(Boolean(owner.factoryFor('session:main')), useResolver);
+    assert.strictEqual(Boolean(owner.factoryFor('session-store:cookie')), useResolver);
   });
 
   test('logging in with correct credentials works', async function (assert) {
@@ -38,13 +48,22 @@ module('Acceptance: Authentication', function (hooks) {
     assert
       .dom('[data-test-reactivity] [data-is-authenticated]')
       .doesNotExist('not authenticated yet.');
+    assert
+      .dom('[data-test-reactivity] [data-access-token]')
+      .doesNotExist('no session data yet.');
     await fillIn('[data-test-identification]', 'identification');
     await fillIn('[data-test-password]', 'password');
     await click('button[type="submit"]');
 
+    const session = currentSession();
+    assert.true(session.get('isAuthenticated'), 'session is authenticated after login');
+    assert.equal(session.get('data.authenticated.access_token'), 'secret token!');
     assert
       .dom('[data-test-reactivity] [data-is-authenticated]')
       .exists('session.isAuthenticated is reactive');
+    assert
+      .dom('[data-test-reactivity] [data-access-token]')
+      .exists('session.data.authenticated.access_token is reactive');
     assert.equal(currentURL(), '/');
   });
 

--- a/packages/test-app/tests/acceptance/authentication-test.ts
+++ b/packages/test-app/tests/acceptance/authentication-test.ts
@@ -34,6 +34,21 @@ module('Acceptance: Authentication', function (hooks) {
     assert.notOk(owner.factoryFor('session-store:cookie'));
   });
 
+  test('authenticateSession works without registering an authenticator', async function (assert) {
+    if (useResolver) {
+      assert.expect(0);
+      return;
+    }
+
+    const { owner } = getContext() as { owner: { factoryFor: (name: string) => unknown } };
+    assert.notOk(owner.factoryFor('authenticator:test'));
+
+    await authenticateSession({ userId: '1' });
+
+    assert.true(currentSession().isAuthenticated);
+    assert.notOk(owner.factoryFor('authenticator:test'));
+  });
+
   test('logging in with correct credentials works', async function (assert) {
     server = new Pretender(function () {
       this.post(`${config.apiHost}/token`, () => [
@@ -53,9 +68,7 @@ module('Acceptance: Authentication', function (hooks) {
     assert
       .dom('[data-test-reactivity] [data-is-authenticated]')
       .doesNotExist('not authenticated yet.');
-    assert
-      .dom('[data-test-reactivity] [data-access-token]')
-      .doesNotExist('no session data yet.');
+    assert.dom('[data-test-reactivity] [data-access-token]').doesNotExist('no session data yet.');
     await fillIn('[data-test-identification]', 'identification');
     await fillIn('[data-test-password]', 'password');
     await click('button[type="submit"]');
@@ -88,7 +101,11 @@ module('Acceptance: Authentication', function (hooks) {
     await click('button[type="submit"]');
 
     assert.equal(currentURL(), '/login');
-    assert.dom('[data-test-error-message]').hasText('Login failed: invalid_grant Documentation of the error codes can be found in the Error Response section of RFC 6749.');
+    assert
+      .dom('[data-test-error-message]')
+      .hasText(
+        'Login failed: invalid_grant Documentation of the error codes can be found in the Error Response section of RFC 6749.'
+      );
   });
 
   module('the protected route', function () {

--- a/packages/test-app/tsconfig.json
+++ b/packages/test-app/tsconfig.json
@@ -8,6 +8,7 @@
     // work with TypeScript.
     "baseUrl": ".",
     "experimentalDecorators": true,
+    "allowJs": true,
 
     "paths": {
       "test-app/tests/*": ["tests/*"],

--- a/packages/test-app/types/session-store-test.ts
+++ b/packages/test-app/types/session-store-test.ts
@@ -1,0 +1,47 @@
+import SessionService from 'ember-simple-auth/services/session';
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Assert<Condition extends true> = Condition;
+
+type SessionData = {
+  authenticated: {
+    userId: string;
+  };
+  locale: string;
+};
+
+declare class CookieSessionService extends SessionService<SessionData, CookieStore> {
+  createSessionStore(owner: any): CookieStore;
+}
+
+class LegacySessionService extends SessionService<SessionData> {
+  declare store: CookieStore;
+}
+
+export type ConfiguredStoreTypeIsUsed = Assert<Equal<CookieSessionService['store'], CookieStore>>;
+export type DefaultStoreRemainsUnknown = Assert<Equal<SessionService['store'], unknown>>;
+export type ConfiguredDataTypeIsPreserved = Assert<
+  Equal<CookieSessionService['data'], SessionData>
+>;
+export type CookieExpirationTime = CookieSessionService['store']['cookieExpirationTime'];
+export type LegacyDeclaredStoreIsPreserved = Assert<
+  Equal<LegacySessionService['store'], CookieStore>
+>;
+export type LegacySessionDataIsPreserved = Assert<Equal<LegacySessionService['data'], SessionData>>;
+export type AuthenticatedUserId = LegacySessionService['data']['authenticated']['userId'];
+
+// @ts-expect-error The configured store has no arbitrary properties.
+export type InvalidStoreProperty = CookieSessionService['store']['notAStoreProperty'];
+
+// @ts-expect-error The session data generic has no arbitrary properties.
+export type InvalidSessionDataProperty = LegacySessionService['data']['notSessionData'];
+
+declare class InvalidStoreSessionService extends SessionService<SessionData, CookieStore> {
+  // @ts-expect-error The factory must return the configured store type.
+  createSessionStore(owner: any): EphemeralStore;
+}

--- a/packages/test-esa/tests/integration/session-reactivity-test.js
+++ b/packages/test-esa/tests/integration/session-reactivity-test.js
@@ -1,0 +1,116 @@
+import { module, skip, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { set } from '@ember/object';
+import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+import Configuration from 'ember-simple-auth/configuration';
+import SessionService from 'ember-simple-auth/services/session';
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
+import TestAuthenticator from 'ember-simple-auth/authenticators/test';
+import FakeCookieService from '../helpers/fake-cookie-service';
+
+function createSession(owner, Store) {
+  owner.register('session-store:test', Store);
+  owner.register('authenticator:test', TestAuthenticator);
+  owner.register(
+    'service:session',
+    class ApplicationSession extends SessionService {
+      createSessionStore(owner) {
+        return new Store(owner);
+      }
+
+      createAuthenticators(owner) {
+        return [new TestAuthenticator(owner)];
+      }
+    }
+  );
+  return owner.lookup('service:session');
+}
+
+class AdaptiveCookieStore extends AdaptiveStore {
+  __isLocalStorageAvailable = false;
+}
+
+const updates = {
+  assignment(store, value) {
+    store.cookieExpirationTime = value;
+  },
+  'Ember.set'(store, value) {
+    set(store, 'cookieExpirationTime', value);
+  },
+  '.set()'(store, value) {
+    store.set('cookieExpirationTime', value);
+  },
+};
+
+for (const useResolver of [true, false]) {
+  module(`Session factory reactivity (useResolver: ${useResolver})`, function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      Configuration.load({ useResolver });
+      this.owner.register('service:cookies', FakeCookieService);
+    });
+
+    hooks.afterEach(function () {
+      Configuration.load({});
+    });
+
+    for (const Store of [CookieStore, AdaptiveCookieStore]) {
+      for (const [method, update] of Object.entries(updates)) {
+        const testUpdate = method === 'assignment' ? skip : test;
+        testUpdate(`${Store.name} remember me updates through ${method}`, async function (assert) {
+          const session = createSession(this.owner, Store);
+          this.store = session.store;
+          const rememberMe = createCache(() => this.store.cookieExpirationTime !== null);
+          const cookies = this.owner.lookup('service:cookies');
+          const expirationCookie = `${this.store.cookieName}-expiration_time`;
+          await session.authenticate('authenticator:test', { token: 'secret' });
+          const persisted = await this.store.restore();
+
+          await render(hbs`<span data-test-expiry>{{this.store.cookieExpirationTime}}</span>`);
+          assert.dom('[data-test-expiry]').hasText('');
+          assert.false(getValue(rememberMe));
+
+          update(this.store, 120);
+          await settled();
+
+          assert.strictEqual(this.store.cookieExpirationTime, 120);
+          assert.true(getValue(rememberMe), 'invalidates cached derived state');
+          assert.dom('[data-test-expiry]').hasText('120');
+          assert.strictEqual(cookies.read(expirationCookie), '120', 'persists the expiration');
+          assert.deepEqual(await this.store.restore(), persisted, 'preserves the session');
+
+          update(this.store, null);
+          await settled();
+
+          assert.strictEqual(this.store.cookieExpirationTime, null);
+          assert.false(getValue(rememberMe));
+          assert.dom('[data-test-expiry]').hasText('');
+          assert.strictEqual(cookies.read(expirationCookie), undefined, 'clears the expiration');
+          assert.deepEqual(await this.store.restore(), persisted, 'preserves the session');
+        });
+      }
+    }
+
+    if (useResolver) {
+      test('cookie properties supplied at creation preserve persistence callbacks', async function (assert) {
+        this.owner.register('session-store:configured', CookieStore);
+        const store = this.owner.factoryFor('session-store:configured').create({
+          cookieName: 'initial-session',
+          cookieExpirationTime: 120,
+        });
+        await store.persist({ token: 'secret' });
+
+        store.cookieName = 'updated-session';
+        await settled();
+
+        assert.deepEqual(await store.restore(), { token: 'secret' });
+        assert.strictEqual(store.cookieExpirationTime, 120);
+        store.destroy();
+      });
+    }
+  });
+}

--- a/packages/test-esa/tests/integration/session-reactivity-test.js
+++ b/packages/test-esa/tests/integration/session-reactivity-test.js
@@ -1,8 +1,8 @@
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { set } from '@ember/object';
+import { computed, defineProperty, set } from '@ember/object';
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 import Configuration from 'ember-simple-auth/configuration';
 import SessionService from 'ember-simple-auth/services/session';
@@ -59,9 +59,32 @@ for (const useResolver of [true, false]) {
     });
 
     for (const Store of [CookieStore, AdaptiveCookieStore]) {
+      if (useResolver) {
+        test(`${Store.name} updates existing computed consumers`, async function (assert) {
+          assert.expect(7);
+          const store = createSession(this.owner, Store).store;
+          const consumer = { store };
+          defineProperty(
+            consumer,
+            'rememberMe',
+            computed('store.cookieExpirationTime', () => store.cookieExpirationTime !== null)
+          );
+          assert.false(consumer.rememberMe);
+
+          for (const [method, update] of Object.entries(updates)) {
+            update(store, 120);
+            await settled();
+            assert.true(consumer.rememberMe, `${method} invalidates the computed property`);
+
+            update(store, null);
+            await settled();
+            assert.false(consumer.rememberMe);
+          }
+        });
+      }
+
       for (const [method, update] of Object.entries(updates)) {
-        const testUpdate = method === 'assignment' ? skip : test;
-        testUpdate(`${Store.name} remember me updates through ${method}`, async function (assert) {
+        test(`${Store.name} remember me updates through ${method}`, async function (assert) {
           const session = createSession(this.owner, Store);
           this.store = session.store;
           const rememberMe = createCache(() => this.store.cookieExpirationTime !== null);

--- a/packages/test-esa/tests/unit/configuration-test.js
+++ b/packages/test-esa/tests/unit/configuration-test.js
@@ -22,11 +22,11 @@ module('Configuration', function (hooks) {
     });
   });
 
-  module('useInternalSessionLookup', function () {
+  module('useResolver', function () {
     test('defaults to true', function (assert) {
       Configuration.load({});
 
-      assert.true(Configuration.useInternalSessionLookup);
+      assert.true(Configuration.useResolver);
     });
   });
 
@@ -43,10 +43,10 @@ module('Configuration', function (hooks) {
       assert.equal(Configuration.routeAfterAuthentication, '/some-route');
     });
 
-    test('sets useInternalSessionLookup correctly', function (assert) {
-      Configuration.load({ useInternalSessionLookup: false });
+    test('sets useResolver correctly', function (assert) {
+      Configuration.load({ useResolver: false });
 
-      assert.false(Configuration.useInternalSessionLookup);
+      assert.false(Configuration.useResolver);
     });
   });
 });

--- a/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
+++ b/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
@@ -6,6 +6,7 @@ import Configuration from 'ember-simple-auth/configuration';
 import InternalSession from 'ember-simple-auth/internal-session';
 import SessionService from 'ember-simple-auth/services/session';
 import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
+import TestAuthenticator from 'ember-simple-auth/authenticators/test';
 import setupSession from 'ember-simple-auth/initializers/setup-session';
 import emberSimpleAuthInitializer from 'ember-simple-auth/initializers/ember-simple-auth';
 
@@ -98,6 +99,62 @@ module('setupSessionService', function (hooks) {
     const service = this.owner.lookup('service:session');
 
     assert.ok(service.session.store instanceof Ephemeral);
+  });
+
+  test('createAuthenticator constructs the test authenticator when useResolver is false', async function (assert) {
+    Configuration.load({ useResolver: false });
+
+    const service = this.owner.lookup('service:session');
+    await service.session.authenticate('authenticator:test', { id: '1' });
+
+    assert.true(service.session.isAuthenticated);
+    assert.equal(service.session.content.authenticated.authenticator, 'authenticator:test');
+  });
+
+  test('createAuthenticator override is used when useResolver is false', async function (assert) {
+    Configuration.load({ useResolver: false });
+    let created;
+
+    this.owner.register(
+      'service:session',
+      class TestSession extends SessionService {
+        createAuthenticator(owner, name) {
+          created = name;
+          return new TestAuthenticator(owner);
+        }
+      }
+    );
+
+    const service = this.owner.lookup('service:session');
+    await service.session.authenticate('authenticator:oauth2', { token: 't' });
+
+    assert.equal(created, 'authenticator:oauth2');
+    assert.true(service.session.isAuthenticated);
+    assert.equal(service.session.content.authenticated.authenticator, 'authenticator:oauth2');
+  });
+
+  test('restore uses createAuthenticator with the persisted authenticator name', async function (assert) {
+    Configuration.load({ useResolver: false });
+    const names = [];
+
+    this.owner.register(
+      'service:session',
+      class TestSession extends SessionService {
+        createAuthenticator(owner, name) {
+          names.push(name);
+          return new TestAuthenticator(owner);
+        }
+      }
+    );
+
+    const service = this.owner.lookup('service:session');
+    await service.session.store.persist({
+      authenticated: { authenticator: 'authenticator:oauth2', token: 't' },
+    });
+    await service.session.restore();
+
+    assert.ok(names.includes('authenticator:oauth2'));
+    assert.true(service.session.isAuthenticated);
   });
 
   test('uses Ephemeral when useResolver is false and createSessionStore is not overridden', function (assert) {

--- a/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
+++ b/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
@@ -101,7 +101,7 @@ module('setupSessionService', function (hooks) {
     assert.ok(service.session.store instanceof Ephemeral);
   });
 
-  test('createAuthenticator constructs the test authenticator when useResolver is false', async function (assert) {
+  test('createAuthenticators constructs the test authenticator when useResolver is false', async function (assert) {
     Configuration.load({ useResolver: false });
 
     const service = this.owner.lookup('service:session');
@@ -111,16 +111,16 @@ module('setupSessionService', function (hooks) {
     assert.equal(service.session.content.authenticated.authenticator, 'authenticator:test');
   });
 
-  test('createAuthenticator override is used when useResolver is false', async function (assert) {
+  test('createAuthenticators override is used when useResolver is false', async function (assert) {
     Configuration.load({ useResolver: false });
-    let created;
 
     this.owner.register(
       'service:session',
       class TestSession extends SessionService {
-        createAuthenticator(owner, name) {
-          created = name;
-          return new TestAuthenticator(owner);
+        createAuthenticators(owner) {
+          return {
+            'authenticator:oauth2': new TestAuthenticator(owner),
+          };
         }
       }
     );
@@ -128,21 +128,20 @@ module('setupSessionService', function (hooks) {
     const service = this.owner.lookup('service:session');
     await service.session.authenticate('authenticator:oauth2', { token: 't' });
 
-    assert.equal(created, 'authenticator:oauth2');
     assert.true(service.session.isAuthenticated);
     assert.equal(service.session.content.authenticated.authenticator, 'authenticator:oauth2');
   });
 
-  test('restore uses createAuthenticator with the persisted authenticator name', async function (assert) {
+  test('restore uses the persisted authenticator name from createAuthenticators', async function (assert) {
     Configuration.load({ useResolver: false });
-    const names = [];
 
     this.owner.register(
       'service:session',
       class TestSession extends SessionService {
-        createAuthenticator(owner, name) {
-          names.push(name);
-          return new TestAuthenticator(owner);
+        createAuthenticators(owner) {
+          return {
+            'authenticator:oauth2': new TestAuthenticator(owner),
+          };
         }
       }
     );
@@ -153,7 +152,6 @@ module('setupSessionService', function (hooks) {
     });
     await service.session.restore();
 
-    assert.ok(names.includes('authenticator:oauth2'));
     assert.true(service.session.isAuthenticated);
   });
 

--- a/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
+++ b/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
@@ -4,7 +4,10 @@ import { registerDeprecationHandler } from '@ember/debug';
 import sinonjs from 'sinon';
 import Configuration from 'ember-simple-auth/configuration';
 import InternalSession from 'ember-simple-auth/internal-session';
+import SessionService from 'ember-simple-auth/services/session';
+import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
 import setupSession from 'ember-simple-auth/initializers/setup-session';
+import emberSimpleAuthInitializer from 'ember-simple-auth/initializers/ember-simple-auth';
 
 const SESSION_MAIN_DEPRECATION_ID = 'ember-simple-auth.session-main';
 
@@ -43,7 +46,7 @@ module('setupSessionService', function (hooks) {
     sinon.restore();
   });
 
-  test('looks up session:main when useInternalSessionLookup is true', function (assert) {
+  test('looks up session:main when useResolver is true', function (assert) {
     const deprecations = collectDeprecations();
 
     assert.equal(this.owner.lookup('service:session').session, this.owner.lookup('session:main'));
@@ -53,8 +56,14 @@ module('setupSessionService', function (hooks) {
     );
   });
 
-  test('constructs InternalSession when useInternalSessionLookup is false', function (assert) {
-    Configuration.load({ useInternalSessionLookup: false });
+  test('looks up session-store:test when useResolver is true', function (assert) {
+    const service = this.owner.lookup('service:session');
+
+    assert.equal(service.session.store, this.owner.lookup('session-store:test'));
+  });
+
+  test('constructs InternalSession when useResolver is false', function (assert) {
+    Configuration.load({ useResolver: false });
     const deprecations = collectDeprecations();
     const originalLookup = this.owner.lookup.bind(this.owner);
     this.owner.lookup = (fullName, ...args) => {
@@ -74,8 +83,33 @@ module('setupSessionService', function (hooks) {
     );
   });
 
-  test('does not register session:main when useInternalSessionLookup is false', function (assert) {
-    Configuration.load({ useInternalSessionLookup: false });
+  test('createSessionStore constructs a store when useResolver is false', function (assert) {
+    Configuration.load({ useResolver: false });
+
+    this.owner.register(
+      'service:session',
+      class TestSession extends SessionService {
+        createSessionStore(owner) {
+          return new Ephemeral(owner);
+        }
+      }
+    );
+
+    const service = this.owner.lookup('service:session');
+
+    assert.ok(service.session.store instanceof Ephemeral);
+  });
+
+  test('uses Ephemeral when useResolver is false and createSessionStore is not overridden', function (assert) {
+    Configuration.load({ useResolver: false });
+
+    const service = this.owner.lookup('service:session');
+
+    assert.ok(service.session.store instanceof Ephemeral);
+  });
+
+  test('does not register session:main when useResolver is false', function (assert) {
+    Configuration.load({ useResolver: false });
     const registry = createRegistry();
 
     setupSession(registry);
@@ -83,7 +117,7 @@ module('setupSessionService', function (hooks) {
     assert.notOk(registry.registrations['session:main']);
   });
 
-  test('registers session:main when useInternalSessionLookup is true', function (assert) {
+  test('registers session:main when useResolver is true', function (assert) {
     const registry = createRegistry();
 
     setupSession(registry);
@@ -91,7 +125,7 @@ module('setupSessionService', function (hooks) {
     assert.ok(registry.registrations['session:main']);
   });
 
-  test('asserts when useInternalSessionLookup is true and session:main is missing', function (assert) {
+  test('asserts when useResolver is true and session:main is missing', function (assert) {
     const originalLookup = this.owner.lookup.bind(this.owner);
     this.owner.lookup = (fullName, ...args) => {
       if (fullName === 'session:main') {
@@ -102,5 +136,59 @@ module('setupSessionService', function (hooks) {
     };
 
     assert.throws(() => this.owner.lookup('service:session'));
+  });
+
+  test('registers session-store:test when useResolver is true', function (assert) {
+    Configuration.load({ useResolver: true });
+    const registry = createRegistry();
+
+    setupSession(registry);
+
+    assert.ok(registry.registrations['session-store:test']);
+  });
+
+  test('does not register session-store:test when useResolver is false', function (assert) {
+    Configuration.load({ useResolver: false });
+    const registry = createRegistry();
+
+    setupSession(registry);
+
+    assert.notOk(registry.registrations['session-store:test']);
+  });
+
+  test('registers built-in session stores when useResolver is true', function (assert) {
+    const registry = {
+      registrations: {},
+      register(name, factory) {
+        this.registrations[name] = factory;
+      },
+      resolveRegistration() {
+        return { rootURL: '/', 'ember-simple-auth': {} };
+      },
+    };
+
+    emberSimpleAuthInitializer.initialize(registry);
+
+    assert.ok(registry.registrations['session-store:adaptive']);
+    assert.ok(registry.registrations['session-store:cookie']);
+    assert.ok(registry.registrations['session-store:local-storage']);
+  });
+
+  test('does not register built-in session stores when useResolver is false', function (assert) {
+    const registry = {
+      registrations: {},
+      register(name, factory) {
+        this.registrations[name] = factory;
+      },
+      resolveRegistration() {
+        return { rootURL: '/', 'ember-simple-auth': { useResolver: false } };
+      },
+    };
+
+    emberSimpleAuthInitializer.initialize(registry);
+
+    assert.notOk(registry.registrations['session-store:adaptive']);
+    assert.notOk(registry.registrations['session-store:cookie']);
+    assert.notOk(registry.registrations['session-store:local-storage']);
   });
 });

--- a/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
+++ b/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
@@ -75,6 +75,15 @@ module('setupSessionService', function (hooks) {
       return originalLookup(fullName, ...args);
     };
 
+    this.owner.register(
+      'service:session',
+      class TestSession extends SessionService {
+        createAuthenticators() {
+          return [];
+        }
+      }
+    );
+
     const service = this.owner.lookup('service:session');
 
     assert.ok(service.session instanceof InternalSession);
@@ -93,6 +102,10 @@ module('setupSessionService', function (hooks) {
         createSessionStore(owner) {
           return new Ephemeral(owner);
         }
+
+        createAuthenticators() {
+          return [];
+        }
       }
     );
 
@@ -101,14 +114,10 @@ module('setupSessionService', function (hooks) {
     assert.ok(service.session.store instanceof Ephemeral);
   });
 
-  test('createAuthenticators constructs the test authenticator when useResolver is false', async function (assert) {
+  test('asserts when createAuthenticators is missing when useResolver is false', function (assert) {
     Configuration.load({ useResolver: false });
 
-    const service = this.owner.lookup('service:session');
-    await service.session.authenticate('authenticator:test', { id: '1' });
-
-    assert.true(service.session.isAuthenticated);
-    assert.equal(service.session.content.authenticated.authenticator, 'authenticator:test');
+    assert.throws(() => this.owner.lookup('service:session'), /createAuthenticators/);
   });
 
   test('createAuthenticators override is used when useResolver is false', async function (assert) {
@@ -118,18 +127,16 @@ module('setupSessionService', function (hooks) {
       'service:session',
       class TestSession extends SessionService {
         createAuthenticators(owner) {
-          return {
-            'authenticator:oauth2': new TestAuthenticator(owner),
-          };
+          return [new TestAuthenticator(owner)];
         }
       }
     );
 
     const service = this.owner.lookup('service:session');
-    await service.session.authenticate('authenticator:oauth2', { token: 't' });
+    await service.session.authenticate('authenticator:test', { token: 't' });
 
     assert.true(service.session.isAuthenticated);
-    assert.equal(service.session.content.authenticated.authenticator, 'authenticator:oauth2');
+    assert.equal(service.session.content.authenticated.authenticator, 'authenticator:test');
   });
 
   test('restore uses the persisted authenticator name from createAuthenticators', async function (assert) {
@@ -139,16 +146,14 @@ module('setupSessionService', function (hooks) {
       'service:session',
       class TestSession extends SessionService {
         createAuthenticators(owner) {
-          return {
-            'authenticator:oauth2': new TestAuthenticator(owner),
-          };
+          return [new TestAuthenticator(owner)];
         }
       }
     );
 
     const service = this.owner.lookup('service:session');
     await service.session.store.persist({
-      authenticated: { authenticator: 'authenticator:oauth2', token: 't' },
+      authenticated: { authenticator: 'authenticator:test', token: 't' },
     });
     await service.session.restore();
 
@@ -157,6 +162,15 @@ module('setupSessionService', function (hooks) {
 
   test('uses Ephemeral when useResolver is false and createSessionStore is not overridden', function (assert) {
     Configuration.load({ useResolver: false });
+
+    this.owner.register(
+      'service:session',
+      class TestSession extends SessionService {
+        createAuthenticators() {
+          return [];
+        }
+      }
+    );
 
     const service = this.owner.lookup('service:session');
 

--- a/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
+++ b/packages/test-esa/tests/unit/initializers/setup-session-service-test.js
@@ -7,6 +7,8 @@ import InternalSession from 'ember-simple-auth/internal-session';
 import SessionService from 'ember-simple-auth/services/session';
 import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
 import TestAuthenticator from 'ember-simple-auth/authenticators/test';
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
+import { authenticateSession } from 'ember-simple-auth/test-support';
 import setupSession from 'ember-simple-auth/initializers/setup-session';
 import emberSimpleAuthInitializer from 'ember-simple-auth/initializers/ember-simple-auth';
 
@@ -61,6 +63,68 @@ module('setupSessionService', function (hooks) {
     const service = this.owner.lookup('service:session');
 
     assert.equal(service.session.store, this.owner.lookup('session-store:test'));
+  });
+
+  test('default configuration uses registered authenticators without ids or factory hooks', async function (assert) {
+    let initCalls = 0;
+    const lookupAuthenticator = sinon.spy(InternalSession.prototype, '_lookupAuthenticator');
+    this.owner.register(
+      'authenticator:legacy',
+      class LegacyAuthenticator extends BaseAuthenticator {
+        init(...args) {
+          super.init(...args);
+          initCalls++;
+        }
+
+        authenticate(data) {
+          return Promise.resolve(data);
+        }
+
+        restore(data) {
+          return Promise.resolve(data);
+        }
+      }
+    );
+    this.owner.register(
+      'service:session',
+      class ApplicationSession extends SessionService {
+        createAuthenticators() {
+          throw new Error('createAuthenticators must require useResolver: false');
+        }
+
+        createSessionStore() {
+          throw new Error('createSessionStore must require useResolver: false');
+        }
+      }
+    );
+
+    const service = this.owner.lookup('service:session');
+    await service.authenticate('authenticator:legacy', { token: 'legacy-token' });
+    await service.session.restore();
+
+    assert.strictEqual(initCalls, 1, 'uses the registered singleton and its existing init hook');
+    assert.ok(lookupAuthenticator.calledWith('authenticator:legacy'));
+    assert.true(service.isAuthenticated);
+    assert.strictEqual(service.data.authenticated.token, 'legacy-token');
+    assert.strictEqual(service.data.authenticated.authenticator, 'authenticator:legacy');
+  });
+
+  test('authenticateSession respects a registered test authenticator by default', async function (assert) {
+    this.owner.register(
+      'authenticator:test',
+      class ApplicationTestAuthenticator extends BaseAuthenticator {
+        authenticate(data) {
+          return Promise.resolve({ ...data, customAuthenticator: true });
+        }
+      }
+    );
+
+    await authenticateSession({ token: 'test-token' });
+    const service = this.owner.lookup('service:session');
+
+    assert.true(service.isAuthenticated);
+    assert.true(service.data.authenticated.customAuthenticator);
+    assert.strictEqual(service.data.authenticated.token, 'test-token');
   });
 
   test('constructs InternalSession when useResolver is false', function (assert) {

--- a/packages/test-esa/tests/unit/internal-session-store-test.js
+++ b/packages/test-esa/tests/unit/internal-session-store-test.js
@@ -46,7 +46,7 @@ module('InternalSession store injection', function (hooks) {
   });
 
   module('authenticator creation', function () {
-    test('looks up authenticators when no createAuthenticator is passed', function (assert) {
+    test('looks up authenticators when no authenticators map is passed', function (assert) {
       this.owner.register('authenticator:test', TestAuthenticator);
       session = new InternalSession(this.owner);
 
@@ -56,27 +56,26 @@ module('InternalSession store injection', function (hooks) {
       );
     });
 
-    test('uses createAuthenticator when it is passed', function (assert) {
+    test('uses the authenticators map when it is passed', function (assert) {
       const store = new Ephemeral(this.owner);
       const authenticator = new TestAuthenticator(this.owner);
       session = new InternalSession(this.owner, store, {
-        createAuthenticator: name => {
-          assert.equal(name, 'authenticator:oauth2');
-          return authenticator;
+        authenticators: {
+          'authenticator:oauth2': authenticator,
         },
       });
 
       assert.equal(session._lookupAuthenticator('authenticator:oauth2'), authenticator);
     });
 
-    test('asserts when useResolver is false and createAuthenticator is missing', function (assert) {
+    test('asserts when useResolver is false and authenticators are missing', function (assert) {
       Configuration.load({ useResolver: false });
       const store = new Ephemeral(this.owner);
       session = new InternalSession(this.owner, store);
 
       assert.throws(
         () => session._lookupAuthenticator('authenticator:test'),
-        /createAuthenticator/
+        /createAuthenticators/
       );
     });
   });

--- a/packages/test-esa/tests/unit/internal-session-store-test.js
+++ b/packages/test-esa/tests/unit/internal-session-store-test.js
@@ -4,6 +4,7 @@ import sinonjs from 'sinon';
 import Configuration from 'ember-simple-auth/configuration';
 import InternalSession from 'ember-simple-auth/internal-session';
 import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
+import TestAuthenticator from 'ember-simple-auth/authenticators/test';
 
 module('InternalSession store injection', function (hooks) {
   setupApplicationTest(hooks);
@@ -41,6 +42,42 @@ module('InternalSession store injection', function (hooks) {
       Configuration.load({ useResolver: false });
 
       assert.throws(() => new InternalSession(this.owner));
+    });
+  });
+
+  module('authenticator creation', function () {
+    test('looks up authenticators when no createAuthenticator is passed', function (assert) {
+      this.owner.register('authenticator:test', TestAuthenticator);
+      session = new InternalSession(this.owner);
+
+      assert.equal(
+        session._lookupAuthenticator('authenticator:test'),
+        this.owner.lookup('authenticator:test')
+      );
+    });
+
+    test('uses createAuthenticator when it is passed', function (assert) {
+      const store = new Ephemeral(this.owner);
+      const authenticator = new TestAuthenticator(this.owner);
+      session = new InternalSession(this.owner, store, {
+        createAuthenticator: name => {
+          assert.equal(name, 'authenticator:oauth2');
+          return authenticator;
+        },
+      });
+
+      assert.equal(session._lookupAuthenticator('authenticator:oauth2'), authenticator);
+    });
+
+    test('asserts when useResolver is false and createAuthenticator is missing', function (assert) {
+      Configuration.load({ useResolver: false });
+      const store = new Ephemeral(this.owner);
+      session = new InternalSession(this.owner, store);
+
+      assert.throws(
+        () => session._lookupAuthenticator('authenticator:test'),
+        /createAuthenticator/
+      );
     });
   });
 });

--- a/packages/test-esa/tests/unit/internal-session-store-test.js
+++ b/packages/test-esa/tests/unit/internal-session-store-test.js
@@ -46,12 +46,20 @@ module('InternalSession store injection', function (hooks) {
   });
 
   module('authenticator creation', function () {
+    class OAuth2Authenticator extends TestAuthenticator {
+      static id = 'oauth2';
+    }
+
+    class ToriiAuthenticator extends TestAuthenticator {
+      static id = 'torii';
+    }
+
     test('looks up authenticators when no authenticators map is passed', function (assert) {
       this.owner.register('authenticator:test', TestAuthenticator);
       session = new InternalSession(this.owner);
 
       assert.equal(
-        session._lookupAuthenticator('authenticator:test'),
+        session._findAuthenticator('authenticator:test'),
         this.owner.lookup('authenticator:test')
       );
     });
@@ -60,12 +68,54 @@ module('InternalSession store injection', function (hooks) {
       const store = new Ephemeral(this.owner);
       const authenticator = new TestAuthenticator(this.owner);
       session = new InternalSession(this.owner, store, {
-        authenticators: {
-          'authenticator:oauth2': authenticator,
-        },
+        authenticators: [authenticator],
       });
 
-      assert.equal(session._lookupAuthenticator('authenticator:oauth2'), authenticator);
+      assert.equal(session._findAuthenticator('authenticator:test'), authenticator);
+    });
+
+    test('findAuthenticator falls back to the registry when the list has no match', function (assert) {
+      this.owner.register('authenticator:oauth2', OAuth2Authenticator);
+      const store = new Ephemeral(this.owner);
+      const listed = new TestAuthenticator(this.owner);
+      session = new InternalSession(this.owner, store, {
+        authenticators: [listed],
+      });
+
+      assert.equal(
+        session._findAuthenticator('authenticator:oauth2'),
+        this.owner.lookup('authenticator:oauth2')
+      );
+    });
+
+    test('findAuthenticator looks up authenticators by id', function (assert) {
+      const store = new Ephemeral(this.owner);
+      const authenticator = new OAuth2Authenticator(this.owner);
+      session = new InternalSession(this.owner, store, {
+        authenticators: [authenticator],
+      });
+
+      assert.equal(session._findAuthenticator('oauth2'), authenticator);
+    });
+
+    test('findAuthenticator looks up authenticators by class', function (assert) {
+      const store = new Ephemeral(this.owner);
+      const authenticator = new OAuth2Authenticator(this.owner);
+      session = new InternalSession(this.owner, store, {
+        authenticators: [authenticator],
+      });
+
+      assert.equal(session._findAuthenticator(OAuth2Authenticator), authenticator);
+    });
+
+    test('findAuthenticator looks up authenticators by instance', function (assert) {
+      const store = new Ephemeral(this.owner);
+      const authenticator = new OAuth2Authenticator(this.owner);
+      session = new InternalSession(this.owner, store, {
+        authenticators: [authenticator],
+      });
+
+      assert.equal(session._findAuthenticator(authenticator), authenticator);
     });
 
     test('asserts when useResolver is false and authenticators are missing', function (assert) {
@@ -74,8 +124,77 @@ module('InternalSession store injection', function (hooks) {
       session = new InternalSession(this.owner, store);
 
       assert.throws(
-        () => session._lookupAuthenticator('authenticator:test'),
+        () => session._findAuthenticator('authenticator:test'),
         /createAuthenticators/
+      );
+    });
+
+    test('asserts when authenticators is not an array', function (assert) {
+      const store = new Ephemeral(this.owner);
+      const authenticator = new OAuth2Authenticator(this.owner);
+
+      assert.throws(
+        () =>
+          new InternalSession(this.owner, store, {
+            authenticators: { oauth2: authenticator },
+          }),
+        /array of authenticator instances/
+      );
+    });
+
+    test('asserts when an authenticator is missing a static id', function (assert) {
+      const store = new Ephemeral(this.owner);
+      class NoIdAuthenticator extends TestAuthenticator {}
+      NoIdAuthenticator.id = undefined;
+
+      assert.throws(
+        () =>
+          new InternalSession(this.owner, store, {
+            authenticators: [new NoIdAuthenticator(this.owner)],
+          }),
+        /static id/
+      );
+    });
+
+    test('asserts when authenticator ids are duplicated', function (assert) {
+      const store = new Ephemeral(this.owner);
+
+      assert.throws(
+        () =>
+          new InternalSession(this.owner, store, {
+            authenticators: [
+              new TestAuthenticator(this.owner),
+              new TestAuthenticator(this.owner),
+            ],
+          }),
+        /duplicate authenticator id "test"/
+      );
+    });
+
+    test('asserts when a class matches multiple authenticators', function (assert) {
+      const store = new Ephemeral(this.owner);
+      session = new InternalSession(this.owner, store, {
+        authenticators: [
+          new OAuth2Authenticator(this.owner),
+          new ToriiAuthenticator(this.owner),
+        ],
+      });
+
+      assert.throws(
+        () => session._findAuthenticator(TestAuthenticator),
+        /Multiple authenticators/
+      );
+    });
+
+    test('asserts when no authenticator matches', function (assert) {
+      const store = new Ephemeral(this.owner);
+      session = new InternalSession(this.owner, store, {
+        authenticators: [new OAuth2Authenticator(this.owner)],
+      });
+
+      assert.throws(
+        () => session._findAuthenticator('authenticator:foo'),
+        /No authenticator for factory "authenticator:foo" could be found!/
       );
     });
   });

--- a/packages/test-esa/tests/unit/internal-session-store-test.js
+++ b/packages/test-esa/tests/unit/internal-session-store-test.js
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import sinonjs from 'sinon';
+import Configuration from 'ember-simple-auth/configuration';
 import InternalSession from 'ember-simple-auth/internal-session';
+import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
 
 module('InternalSession store injection', function (hooks) {
   setupApplicationTest(hooks);
@@ -14,6 +16,7 @@ module('InternalSession store injection', function (hooks) {
   });
 
   hooks.afterEach(function () {
+    Configuration.load({});
     if (session && session !== this.owner.lookup('session:main')) {
       session.destroy();
     }
@@ -21,14 +24,23 @@ module('InternalSession store injection', function (hooks) {
   });
 
   module('session store injection', function () {
-    test('looks up the test session store when isTesting()', function (assert) {
-      session = this.owner.lookup('session:main');
+    test('looks up the test session store when no store is passed', function (assert) {
+      session = new InternalSession(this.owner);
+
       assert.equal(session.get('store'), this.owner.lookup('session-store:test'));
     });
 
-    test('looks up the test session store when created without the resolver', function (assert) {
-      session = new InternalSession(this.owner);
-      assert.equal(session.get('store'), this.owner.lookup('session-store:test'));
+    test('uses the store passed to the constructor', function (assert) {
+      const store = new Ephemeral(this.owner);
+      session = new InternalSession(this.owner, store);
+
+      assert.equal(session.get('store'), store);
+    });
+
+    test('asserts when constructed without a session store', function (assert) {
+      Configuration.load({ useResolver: false });
+
+      assert.throws(() => new InternalSession(this.owner));
     });
   });
 });

--- a/packages/test-esa/tests/unit/internal-session-store-test.js
+++ b/packages/test-esa/tests/unit/internal-session-store-test.js
@@ -118,15 +118,17 @@ module('InternalSession store injection', function (hooks) {
       assert.equal(session._findAuthenticator(authenticator), authenticator);
     });
 
-    test('asserts when useResolver is false and authenticators are missing', function (assert) {
+    test('does not fall back to the resolver when authenticators are missing', function (assert) {
       Configuration.load({ useResolver: false });
       const store = new Ephemeral(this.owner);
       session = new InternalSession(this.owner, store);
+      const lookup = sinon.spy(this.owner, 'lookup');
 
       assert.throws(
         () => session._findAuthenticator('authenticator:test'),
-        /createAuthenticators/
+        /No authenticator for factory "authenticator:test" could be found!/
       );
+      assert.notOk(lookup.calledWith('authenticator:test'), 'does not fall back to the registry');
     });
 
     test('asserts when authenticators is not an array', function (assert) {
@@ -152,7 +154,21 @@ module('InternalSession store injection', function (hooks) {
           new InternalSession(this.owner, store, {
             authenticators: [new NoIdAuthenticator(this.owner)],
           }),
-        /static id/
+        /static string id/
+      );
+    });
+
+    test('asserts when an authenticator has a non-string id', function (assert) {
+      const store = new Ephemeral(this.owner);
+      class InvalidIdAuthenticator extends TestAuthenticator {}
+      InvalidIdAuthenticator.id = 123;
+
+      assert.throws(
+        () =>
+          new InternalSession(this.owner, store, {
+            authenticators: [new InvalidIdAuthenticator(this.owner)],
+          }),
+        /static string id/
       );
     });
 
@@ -162,10 +178,7 @@ module('InternalSession store injection', function (hooks) {
       assert.throws(
         () =>
           new InternalSession(this.owner, store, {
-            authenticators: [
-              new TestAuthenticator(this.owner),
-              new TestAuthenticator(this.owner),
-            ],
+            authenticators: [new TestAuthenticator(this.owner), new TestAuthenticator(this.owner)],
           }),
         /duplicate authenticator id "test"/
       );
@@ -174,16 +187,10 @@ module('InternalSession store injection', function (hooks) {
     test('asserts when a class matches multiple authenticators', function (assert) {
       const store = new Ephemeral(this.owner);
       session = new InternalSession(this.owner, store, {
-        authenticators: [
-          new OAuth2Authenticator(this.owner),
-          new ToriiAuthenticator(this.owner),
-        ],
+        authenticators: [new OAuth2Authenticator(this.owner), new ToriiAuthenticator(this.owner)],
       });
 
-      assert.throws(
-        () => session._findAuthenticator(TestAuthenticator),
-        /Multiple authenticators/
-      );
+      assert.throws(() => session._findAuthenticator(TestAuthenticator), /Multiple authenticators/);
     });
 
     test('asserts when no authenticator matches', function (assert) {
@@ -196,6 +203,45 @@ module('InternalSession store injection', function (hooks) {
         () => session._findAuthenticator('authenticator:foo'),
         /No authenticator for factory "authenticator:foo" could be found!/
       );
+    });
+
+    ['class', 'instance'].forEach(referenceType => {
+      test(`authenticates and restores using an authenticator ${referenceType}`, async function (assert) {
+        Configuration.load({ useResolver: false });
+        const store = new Ephemeral(this.owner);
+        const authenticator = new OAuth2Authenticator(this.owner);
+        const initialSession = new InternalSession(this.owner, store, {
+          authenticators: [authenticator],
+        });
+        const reference = referenceType === 'class' ? OAuth2Authenticator : authenticator;
+
+        await initialSession.authenticate(reference, { token: 'secret' });
+        const persisted = await store.restore();
+
+        assert.equal(persisted.authenticated.authenticator, 'oauth2');
+
+        initialSession.destroy();
+        const restoredStore = new Ephemeral(this.owner);
+        await restoredStore.persist(persisted);
+        session = new InternalSession(this.owner, restoredStore, {
+          authenticators: [new OAuth2Authenticator(this.owner)],
+        });
+        await session.restore();
+
+        assert.true(session.isAuthenticated);
+        assert.equal(session.content.authenticated.token, 'secret');
+      });
+    });
+
+    test('destroys injected stores and authenticators with the session', function (assert) {
+      const store = new Ephemeral(this.owner);
+      const authenticator = new OAuth2Authenticator(this.owner);
+      session = new InternalSession(this.owner, store, { authenticators: [authenticator] });
+
+      session.destroy();
+
+      assert.true(store.isDestroying);
+      assert.true(authenticator.isDestroying);
     });
   });
 });

--- a/packages/test-esa/tests/unit/internal-session-store-test.js
+++ b/packages/test-esa/tests/unit/internal-session-store-test.js
@@ -180,7 +180,7 @@ module('InternalSession store injection', function (hooks) {
           new InternalSession(this.owner, store, {
             authenticators: [new TestAuthenticator(this.owner), new TestAuthenticator(this.owner)],
           }),
-        /duplicate authenticator id "test"/
+        /unique, non-empty static string id/
       );
     });
 

--- a/packages/test-esa/tests/unit/services/session-test.js
+++ b/packages/test-esa/tests/unit/services/session-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
-import EmberObject, { set } from '@ember/object';
+import EmberObject, { computed, set } from '@ember/object';
 import sinonjs from 'sinon';
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 import { MockSessionStorage } from '../../helpers/mocked-session-storage';
 
 module('SessionService', function (hooks) {
@@ -40,6 +41,73 @@ module('SessionService', function (hooks) {
 
   hooks.afterEach(function () {
     sinon.restore();
+  });
+
+  test('updates classic computed properties that depend on the public session properties', function (assert) {
+    const consumer = EmberObject.extend({
+      session: sessionService,
+      signedIn: computed('session.isAuthenticated', function () {
+        return this.session.isAuthenticated;
+      }),
+      token: computed('session.data.authenticated.token', function () {
+        return this.session.data.authenticated.token;
+      }),
+      storage: computed('session.store', function () {
+        return this.session.store;
+      }),
+      transition: computed('session.attemptedTransition', function () {
+        return this.session.attemptedTransition;
+      }),
+    }).create();
+
+    assert.false(consumer.get('signedIn'));
+    assert.strictEqual(consumer.get('token'), undefined);
+    assert.strictEqual(consumer.get('storage'), session.store);
+    assert.strictEqual(consumer.get('transition'), null);
+
+    const transition = {};
+    const store = {};
+    session.setProperties({
+      isAuthenticated: true,
+      content: { authenticated: { token: 'updated' } },
+      store,
+      attemptedTransition: transition,
+    });
+
+    assert.true(consumer.get('signedIn'));
+    assert.strictEqual(consumer.get('token'), 'updated');
+    assert.strictEqual(consumer.get('storage'), store);
+    assert.strictEqual(consumer.get('transition'), transition);
+    consumer.destroy();
+  });
+
+  test('notifies synchronous observers when authentication changes', async function (assert) {
+    this.owner.register(
+      'authenticator:legacy',
+      class LegacyAuthenticator extends BaseAuthenticator {
+        authenticate() {
+          return Promise.resolve({ token: 'secret' });
+        }
+      }
+    );
+    const observedStates = [];
+    const onChange = () => observedStates.push(sessionService.isAuthenticated);
+    sessionService.addObserver('isAuthenticated', null, onChange, true);
+
+    await sessionService.authenticate('authenticator:legacy');
+    await sessionService.invalidate();
+
+    sessionService.removeObserver('isAuthenticated', null, onChange, true);
+    assert.deepEqual(observedStates, [true, false]);
+  });
+
+  test('updates existing session data references when setting a custom property', function (assert) {
+    const data = sessionService.data;
+
+    sessionService.set('data.preference', 'dark');
+
+    assert.strictEqual(data.preference, 'dark');
+    assert.strictEqual(sessionService.data, data);
   });
 
   module('isAuthenticated', function () {

--- a/packages/test-esa/tests/unit/session-stores/adaptive-test.js
+++ b/packages/test-esa/tests/unit/session-stores/adaptive-test.js
@@ -6,6 +6,10 @@ import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
 import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
+import LocalStorageStore from 'ember-simple-auth/session-stores/local-storage';
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+import { setupStore } from 'ember-simple-auth/session-stores/base';
+import Configuration from 'ember-simple-auth/configuration';
 
 module('AdaptiveStore', function (hooks) {
   setupTest(hooks);
@@ -128,6 +132,36 @@ module('AdaptiveStore', function (hooks) {
           })
         )
       );
+    });
+  });
+
+  module('useResolver', function (hooks) {
+    hooks.afterEach(function () {
+      Configuration.load({});
+    });
+
+    test('constructs LocalStorageStore when the flag is false', function (assert) {
+      Configuration.load({ useResolver: false });
+      this.owner.register('service:cookies', FakeCookieService);
+
+      class TestAdaptiveStore extends AdaptiveStore {
+        __isLocalStorageAvailable = true;
+      }
+      let store = setupStore(new TestAdaptiveStore(this.owner));
+
+      assert.ok(store.get('_store') instanceof LocalStorageStore);
+    });
+
+    test('constructs CookieStore when the flag is false', function (assert) {
+      Configuration.load({ useResolver: false });
+      this.owner.register('service:cookies', FakeCookieService);
+
+      class TestAdaptiveStore extends AdaptiveStore {
+        __isLocalStorageAvailable = false;
+      }
+      let store = setupStore(new TestAdaptiveStore(this.owner));
+
+      assert.ok(store.get('_store') instanceof CookieStore);
     });
   });
 });

--- a/packages/test-esa/tests/unit/session-stores/adaptive-test.js
+++ b/packages/test-esa/tests/unit/session-stores/adaptive-test.js
@@ -14,6 +14,32 @@ import Configuration from 'ember-simple-auth/configuration';
 module('AdaptiveStore', function (hooks) {
   setupTest(hooks);
 
+  test('classic subclasses preserve init and unrelated _setup methods', function (assert) {
+    Configuration.load({ useResolver: true });
+    let initCalls = 0;
+    let customSetupCalls = 0;
+    this.owner.register('service:cookies', FakeCookieService);
+    this.owner.register(
+      'session-store:adaptive',
+      AdaptiveStore.extend({
+        __isLocalStorageAvailable: true,
+        init() {
+          initCalls++;
+          this._super(...arguments);
+        },
+        _setup() {
+          customSetupCalls++;
+        },
+      })
+    );
+
+    const store = this.owner.lookup('session-store:adaptive');
+
+    assert.strictEqual(initCalls, 1);
+    assert.strictEqual(customSetupCalls, 0);
+    assert.ok(store.get('_store') instanceof LocalStorageStore);
+  });
+
   module('when localStorage is available', function (hooks) {
     itBehavesLikeAStore({
       hooks,

--- a/packages/test-esa/tests/unit/session-stores/cookie-test.js
+++ b/packages/test-esa/tests/unit/session-stores/cookie-test.js
@@ -1,4 +1,4 @@
-import { module } from 'qunit';
+import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
@@ -15,6 +15,33 @@ class TestCookieStoreBehavior extends CookieStore {
 
 module('CookieStore', function (hooks) {
   setupTest(hooks);
+
+  test('existing subclass setup properties do not replace store initialization', function (assert) {
+    let initCalls = 0;
+    let customSetupCalls = 0;
+    this.owner.register('service:cookies', FakeCookieService);
+    this.owner.register(
+      'session-store:cookie',
+      class ApplicationCookieStore extends CookieStore {
+        _setupRan = true;
+
+        init(...args) {
+          initCalls++;
+          super.init(...args);
+        }
+
+        _setup() {
+          customSetupCalls++;
+        }
+      }
+    );
+
+    const store = this.owner.lookup('session-store:cookie');
+
+    assert.strictEqual(initCalls, 1);
+    assert.strictEqual(customSetupCalls, 0);
+    assert.strictEqual(store._fastboot, this.owner.lookup('service:fastboot'));
+  });
 
   module('StoreBehavior', function (hooks) {
     itBehavesLikeAStore({


### PR DESCRIPTION
Follow up #3120 

- Supersedes `useInternalSessionLookup` flag introduced by #3120
- Introduces `useResolver` which tells addon to either pull dependencies from the registry or initialize them on its own