### PR TITLE
Type `SessionService#store` as `BaseStore` instead of `unknown`

### DIFF
--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -32,7 +32,7 @@ type RouteOrCallback = string | (() => void);
 type InternalSessionMock<Data> = {
   isAuthenticated: boolean;
   content: Data;
-  store: unknown;
+  store: EsaBaseSessionStore;
   attemptedTransition: null;
   on: (event: 'authenticationSucceeded' | 'invalidationSucceeded', cb: () => void) => void;
   authenticate: (authenticator: string, ...args: any[]) => Promise<void>;
@@ -147,7 +147,7 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @default null
     @public
   */
-  @readOnly('session.store') declare store: unknown;
+  @readOnly('session.store') declare store: EsaBaseSessionStore;
 
   /**
     A previously attempted but intercepted transition (e.g. by the


### PR DESCRIPTION
`SessionService#store` is typed as `unknown`, so calling anything on it fails to compile:

```ts
await this.session.store.persist(this.session.data);
// TS2571: Object is of type 'unknown'.
```

Looks like a leftover from #2873 — `internal-session.js` is still JavaScript, so the service describes it with the hand-written `InternalSessionMock` shape. `BaseStore` is already imported as a type in this file and already types the sibling `setRedirectTarget` / `getRedirectTarget` / `clearRedirectTarget` members of that shape, and the doc block already says `@type BaseStore`.
